### PR TITLE
Add PC registers per pipeline stage

### DIFF
--- a/src/henad.v
+++ b/src/henad.v
@@ -5,7 +5,14 @@ module henad(
     input wire rst
 );
     // Pipeline registers
-    reg [11:0] if_pc;
+    // Program counter value for each stage
+    reg [11:0] if_pc; // fetch stage PC
+    reg [11:0] id_pc; // decode stage PC
+    reg [11:0] ex_pc; // execute stage PC
+    reg [11:0] ma_pc; // memory address stage PC
+    reg [11:0] ro_pc; // register operation stage PC
+
+    // Instruction flowing through the pipeline
     reg [11:0] id_instr;
     reg [11:0] ex_instr;
     reg [11:0] ma_instr;
@@ -41,13 +48,25 @@ module henad(
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             if_pc <= 12'b0;
+            id_pc <= 12'b0;
+            ex_pc <= 12'b0;
+            ma_pc <= 12'b0;
+            ro_pc <= 12'b0;
+
             id_instr <= 12'b0;
             ex_instr <= 12'b0;
             ma_instr <= 12'b0;
             ro_instr <= 12'b0;
         end else begin
             // Advance pipeline
+            // Update PCs
             if_pc <= next_pc;
+            id_pc <= ifid_pc;
+            ex_pc <= id_pc;
+            ma_pc <= ex_pc;
+            ro_pc <= ma_pc;
+
+            // Advance instructions
             id_instr <= ifid_instr;
             ex_instr <= id_instr;
             ma_instr <= ex_instr;

--- a/src/latch2idex.v
+++ b/src/latch2idex.v
@@ -1,4 +1,20 @@
 // latch2idex.v
-module latch2idex();
-    // Latch between ID and EX
+// Latch between Instruction Decode (ID) and Execute (EX) stages
+module latch2idex(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] instr_in,
+    input  wire [11:0] pc_in,
+    output reg  [11:0] instr_out,
+    output reg  [11:0] pc_out
+);
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            instr_out <= 12'b0;
+            pc_out    <= 12'b0;
+        end else begin
+            instr_out <= instr_in;
+            pc_out    <= pc_in;
+        end
+    end
 endmodule

--- a/src/latch3exma.v
+++ b/src/latch3exma.v
@@ -1,4 +1,20 @@
 // latch3exma.v
-module latch3exma();
-    // Latch between EX and MA
+// Latch between Execute (EX) and Memory Address (MA) stages
+module latch3exma(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] instr_in,
+    input  wire [11:0] pc_in,
+    output reg  [11:0] instr_out,
+    output reg  [11:0] pc_out
+);
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            instr_out <= 12'b0;
+            pc_out    <= 12'b0;
+        end else begin
+            instr_out <= instr_in;
+            pc_out    <= pc_in;
+        end
+    end
 endmodule

--- a/src/latch4mamo.v
+++ b/src/latch4mamo.v
@@ -1,4 +1,20 @@
 // latch4mamo.v
-module latch4mamo();
-    // Latch between MA and MO
+// Latch between Memory Address (MA) and Memory Operation (MO) stages
+module latch4mamo(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] instr_in,
+    input  wire [11:0] pc_in,
+    output reg  [11:0] instr_out,
+    output reg  [11:0] pc_out
+);
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            instr_out <= 12'b0;
+            pc_out    <= 12'b0;
+        end else begin
+            instr_out <= instr_in;
+            pc_out    <= pc_in;
+        end
+    end
 endmodule

--- a/src/latch4mora.v
+++ b/src/latch4mora.v
@@ -1,4 +1,20 @@
 // latch4mora.v
-module latch4mora();
-    // Latch between MO and RA
+// Latch between Memory Operation (MO) and Register Address (RA) stages
+module latch4mora(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] instr_in,
+    input  wire [11:0] pc_in,
+    output reg  [11:0] instr_out,
+    output reg  [11:0] pc_out
+);
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            instr_out <= 12'b0;
+            pc_out    <= 12'b0;
+        end else begin
+            instr_out <= instr_in;
+            pc_out    <= pc_in;
+        end
+    end
 endmodule

--- a/src/latch5raro.v
+++ b/src/latch5raro.v
@@ -1,4 +1,20 @@
 // latch5raro.v
-module latch5raro();
-    // Latch between RA and RO
+// Latch between Register Address (RA) and Register Operation (RO) stages
+module latch5raro(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] instr_in,
+    input  wire [11:0] pc_in,
+    output reg  [11:0] instr_out,
+    output reg  [11:0] pc_out
+);
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            instr_out <= 12'b0;
+            pc_out    <= 12'b0;
+        end else begin
+            instr_out <= instr_in;
+            pc_out    <= pc_in;
+        end
+    end
 endmodule

--- a/src/stage2id.v
+++ b/src/stage2id.v
@@ -1,4 +1,13 @@
 // stage2id.v
-module stage2id();
-    // Instruction Decode logic
+// Simple placeholder for the Instruction Decode stage.  The stage
+// currently just passes the program counter through so that each
+// pipeline stage retains its own PC value.
+module stage2id(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] pc_in,
+    output wire [11:0] pc_out
+);
+    // No decode logic yet.  Simply propagate the PC.
+    assign pc_out = pc_in;
 endmodule

--- a/src/stage3ex.v
+++ b/src/stage3ex.v
@@ -1,4 +1,12 @@
 // stage3ex.v
-module stage3ex();
-    // Execute logic
+// Placeholder for the Execute stage.  Like the other stages, it
+// currently just forwards the program counter to the next stage.
+module stage3ex(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] pc_in,
+    output wire [11:0] pc_out
+);
+    // No execute logic yet.  Propagate the PC.
+    assign pc_out = pc_in;
 endmodule

--- a/src/stage4ma.v
+++ b/src/stage4ma.v
@@ -1,4 +1,13 @@
 // stage4ma.v
-module stage4ma();
-    // Memory Address logic
+// Memory Address stage placeholder.  It simply passes the program
+// counter to the Memory Operation stage so that each stage keeps its
+// own PC value.
+module stage4ma(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] pc_in,
+    output wire [11:0] pc_out
+);
+    // No memory address logic yet.  Propagate the PC.
+    assign pc_out = pc_in;
 endmodule

--- a/src/stage4mo.v
+++ b/src/stage4mo.v
@@ -1,4 +1,12 @@
 // stage4mo.v
-module stage4mo();
-    // Memory Operation logic
+// Memory Operation stage placeholder.  The PC is simply passed to the
+// next stage.
+module stage4mo(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] pc_in,
+    output wire [11:0] pc_out
+);
+    // No memory operation logic yet.  Propagate the PC.
+    assign pc_out = pc_in;
 endmodule

--- a/src/stage5ra.v
+++ b/src/stage5ra.v
@@ -1,4 +1,12 @@
 // stage5ra.v
-module stage5ra();
-    // Register Address logic
+// Register Address stage placeholder.  Simply forwards the program
+// counter so that the final stage sees the same PC value.
+module stage5ra(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] pc_in,
+    output wire [11:0] pc_out
+);
+    // No register address logic yet.  Propagate the PC.
+    assign pc_out = pc_in;
 endmodule

--- a/src/stage5ro.v
+++ b/src/stage5ro.v
@@ -1,4 +1,12 @@
 // stage5ro.v
-module stage5ro();
-    // Register Operation logic
+// Register Operation stage placeholder.  The program counter is simply
+// passed through.
+module stage5ro(
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [11:0] pc_in,
+    output wire [11:0] pc_out
+);
+    // No register operation logic yet.  Propagate the PC.
+    assign pc_out = pc_in;
 endmodule


### PR DESCRIPTION
## Summary
- add 12‑bit PC registers for each pipeline stage in `henad.v`
- propagate the PC between stages when advancing the pipeline
- implement PC latching modules for all pipeline latch stubs
- pass PCs through each stage as placeholders

## Testing
- `iverilog -o build/test src/henad.v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684949a7bd34832f8211e33dd81031c7