### PR TITLE
Add observable 8MHz testbench

### DIFF
--- a/src/testbench.v
+++ b/src/testbench.v
@@ -1,6 +1,47 @@
 // testbench.v
-// Top-level testbench for Henad core
-module testbench();
-    // Instantiate top-level henad module here
-    // Add clock, reset, and stimulus
+// Basic simulation testbench for the Henad core.  The goal is simply
+// to exercise the pipeline and print out the program counter value at
+// every stage so that the flow through the pipeline can be observed.
+
+`timescale 1ns/1ps
+
+module testbench;
+    // Clock and reset
+    reg clk;
+    reg rst;
+
+    // Instantiate the core
+    henad uut (
+        .clk(clk),
+        .rst(rst)
+    );
+
+    // Generate an 8MHz clock -> 125ns period -> 62.5ns half period
+    initial clk = 1'b0;
+    always #62.5 clk = ~clk;
+
+    // Drive reset and finish after a number of cycles
+    initial begin
+        rst = 1'b1;
+        // Hold reset for two clock cycles
+        #250;
+        rst = 1'b0;
+
+        // Let the simulation run for some cycles
+        repeat (20) @(posedge clk);
+        $finish;
+    end
+
+    // Display reset and PC values on every tick
+    integer tick = 0;
+    always @(posedge clk) begin
+        $display("tick %0d : rst=%b IF=%h ID=%h EX=%h MA=%h RO=%h",
+                 tick, rst,
+                 uut.if_pc,
+                 uut.id_pc,
+                 uut.ex_pc,
+                 uut.ma_pc,
+                 uut.ro_pc);
+        tick = tick + 1;
+    end
 endmodule


### PR DESCRIPTION
## Summary
- implement a simple testbench for the Henad core
- generate an 8 MHz clock and drive reset
- display the reset state and PCs from all pipeline stages at every tick

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp | head`

------
https://chatgpt.com/codex/tasks/task_e_684a82ea745c832fa8164a49834bd18a