### PR TITLE
Add split-stage PC output in testbench

### DIFF
--- a/src/testbench.v
+++ b/src/testbench.v
@@ -35,12 +35,16 @@ module testbench;
     // Display reset and PC values on every tick
     integer tick = 0;
     always @(posedge clk) begin
-        $display("tick %0d : rst=%b IF=%h ID=%h EX=%h MA=%h RO=%h",
+        $display("tick %0d : rst=%b IAIF=%h IF=%h ID=%h EX=%h MA=%h MAMO=%h MORA=%h RARO=%h RO=%h",
                  tick, rst,
+                 uut.iaif_pc,
                  uut.if_pc,
                  uut.id_pc,
                  uut.ex_pc,
                  uut.ma_pc,
+                 uut.mamo_pc,
+                 uut.mora_pc,
+                 uut.raro_pc,
                  uut.ro_pc);
         tick = tick + 1;
     end


### PR DESCRIPTION
## Summary
- extend testbench display string to show program counter values for the split pipeline stages

## Testing
- `iverilog -g2012 -o test.vvp src/*.v && vvp test.vvp | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684c0d4f2708832f9fc8fd801764d18b