### PR TITLE
Ensure PC advances every tick

### DIFF
--- a/src/henad.v
+++ b/src/henad.v
@@ -60,7 +60,11 @@ module henad(
     control1if u_control1if(
         .clk(clk),
         .rst(rst),
-        .pc_in(iaif_pc),
+        // Feed the current fetch stage PC directly so the next PC
+        // increment is based on the most recent value rather than the
+        // one stored in the IA/IF latch. This keeps the PC advancing on
+        // every clock tick.
+        .pc_in(if_pc),
         .pc_out(next_pc),
         .mem_addr(instr_mem_addr),
         .instr_mem_data(instr_mem_data),


### PR DESCRIPTION
## Summary
- adjust IF stage to compute next PC from current value

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_684fe2404094832fb62cee854eaa201a