### PR TITLE
Fix module instantiations

### DIFF
--- a/src/control1ia.v
+++ b/src/control1ia.v
@@ -3,7 +3,9 @@ module control1ia(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] pc_in,
-    output wire [11:0] pc_out
+    output wire [11:0] pc_out,
+    // Address output to the instruction memory
+    output wire [11:0] mem_addr
 );
     // Output from the stage before being latched
     wire [11:0] stage_pc;
@@ -14,7 +16,8 @@ module control1ia(
         .clk(clk),
         .rst(rst),
         .pc_in(pc_in),
-        .pc_out(stage_pc)
+        .pc_out(stage_pc),
+        .mem_addr(mem_addr)
     );
 
     // Latch between IA and IF stages

--- a/src/control1if.v
+++ b/src/control1if.v
@@ -5,7 +5,6 @@ module control1if(
     input wire [11:0] pc_in,
     output wire [11:0] pc_out,
     // Instruction memory interface
-    output wire [11:0] mem_addr,
     input wire [11:0] instr_mem_data,
     output wire [11:0] ifid_instr,
     output wire [11:0] ifid_pc
@@ -15,8 +14,7 @@ module control1if(
         .clk(clk),
         .rst(rst),
         .pc_in(pc_in),
-        .instr_out(), // Not used here, instr comes from memory
-        .mem_addr(mem_addr)
+        .instr_out() // Instruction comes from memory
     );
     // Latch1ifid: latch instruction and PC
     latch1ifid u_latch1ifid(

--- a/src/henad.v
+++ b/src/henad.v
@@ -33,8 +33,8 @@ module henad(
         .clk(clk),
         .rst(rst),
         .pc_in(ia_pc),
-        .pc_out(iaif_pc)
-        .mem_addr(instr_mem_addr),
+        .pc_out(iaif_pc),
+        .mem_addr(instr_mem_addr)
     );
 
     // IF stage control
@@ -42,9 +42,10 @@ module henad(
         .clk(clk),
         .rst(rst),
         .pc_in(iaif_pc),
-        .pc_out(ifid_pc),
+        .pc_out(ia_pc),
         .instr_mem_data(instr_mem_data),
         .ifid_instr(ifid_instr),
+        .ifid_pc(ifid_pc)
     );
     meminstr u_meminstr(
         .clk(clk),

--- a/src/stage1ia.v
+++ b/src/stage1ia.v
@@ -3,10 +3,16 @@ module stage1ia(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] pc_in,
-    output wire [11:0] pc_out
+    output wire [11:0] pc_out,
+    // Address sent to instruction memory.  Splitting the fetch
+    // stage allows the address to be registered one cycle earlier
+    // than the data fetch.
+    output wire [11:0] mem_addr
 );
     // No instruction address logic yet.  Simply propagate the PC so
     // that later stages each retain their own copy of the program
     // counter value.
-    assign pc_out = pc_in;
+    assign pc_out  = pc_in;
+    // The instruction memory address is simply the current PC value.
+    assign mem_addr = pc_in;
 endmodule

--- a/src/stage1if.v
+++ b/src/stage1if.v
@@ -3,10 +3,7 @@ module stage1if(
     input wire clk,
     input wire rst,
     input wire [11:0] pc_in,
-    output wire [11:0] instr_out,
-    output wire [11:0] mem_addr
+    output wire [11:0] instr_out
 );
-    // For now, just pass PC to memory address
-    assign mem_addr = pc_in;
     // instr_out will be connected externally from memory
 endmodule

--- a/src/testbench.v
+++ b/src/testbench.v
@@ -40,7 +40,7 @@ module testbench;
                  uut.ia_pc,
                  uut.iaif_pc,
                  uut.ifid_pc,
-                 uut.ifex_pc,
+                 uut.idex_pc,
                  uut.exma_pc,
                  uut.mamo_pc,
                  uut.mora_pc,


### PR DESCRIPTION
## Summary
- wire up IF stage correctly
- correct PC display signal name in testbench
- stage1ia now drives the instruction memory address instead of IF

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp | head`

------
https://chatgpt.com/codex/tasks/task_e_684fefc5fa90832fb1fc0ed564efc3bf