### PR TITLE
Add instruction set pipeline signal

### DIFF
--- a/src/control2id.v
+++ b/src/control2id.v
@@ -4,18 +4,25 @@ module control2id(
     input  wire        rst,
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     output wire [11:0] pc_out,
-    output wire [11:0] instr_out
+    output wire [11:0] instr_out,
+    output wire [3:0]  instr_set_out
 );
     // Output of the stage before being latched
     wire [11:0] stage_pc;
 
     // Stage 2 Instruction Decode
+    wire [3:0] stage_set;
+
     stage2id u_stage2id(
         .clk(clk),
         .rst(rst),
+        .instr_in(instr_in),
+        .instr_set_in(instr_set_in),
         .pc_in(pc_in),
-        .pc_out(stage_pc)
+        .pc_out(stage_pc),
+        .instr_set_out(stage_set)
     );
 
     // Latch between ID and EX stages
@@ -23,8 +30,10 @@ module control2id(
         .clk(clk),
         .rst(rst),
         .instr_in(instr_in),
+        .instr_set_in(stage_set),
         .pc_in(stage_pc),
         .instr_out(instr_out),
+        .instr_set_out(instr_set_out),
         .pc_out(pc_out)
     );
 endmodule

--- a/src/control3ex.v
+++ b/src/control3ex.v
@@ -4,12 +4,15 @@ module control3ex(
     input  wire        rst,
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     output wire [11:0] pc_out,
-    output wire [11:0] instr_out
+    output wire [11:0] instr_out,
+    output wire [3:0]  instr_set_out
 );
     wire [11:0] stage_pc;
 
     // Execute stage
+
     stage3ex u_stage3ex(
         .clk(clk),
         .rst(rst),
@@ -22,8 +25,10 @@ module control3ex(
         .clk(clk),
         .rst(rst),
         .instr_in(instr_in),
+        .instr_set_in(instr_set_in),
         .pc_in(stage_pc),
         .instr_out(instr_out),
+        .instr_set_out(instr_set_out),
         .pc_out(pc_out)
     );
 endmodule

--- a/src/control4ma.v
+++ b/src/control4ma.v
@@ -4,8 +4,10 @@ module control4ma(
     input  wire        rst,
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     output wire [11:0] pc_out,
-    output wire [11:0] instr_out
+    output wire [11:0] instr_out,
+    output wire [3:0]  instr_set_out
 );
     wire [11:0] stage_pc;
 
@@ -22,8 +24,10 @@ module control4ma(
         .clk(clk),
         .rst(rst),
         .instr_in(instr_in),
+        .instr_set_in(instr_set_in),
         .pc_in(stage_pc),
         .instr_out(instr_out),
+        .instr_set_out(instr_set_out),
         .pc_out(pc_out)
     );
 endmodule

--- a/src/control4mo.v
+++ b/src/control4mo.v
@@ -4,8 +4,10 @@ module control4mo(
     input  wire        rst,
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     output wire [11:0] pc_out,
-    output wire [11:0] instr_out
+    output wire [11:0] instr_out,
+    output wire [3:0]  instr_set_out
 );
     wire [11:0] stage_pc;
 
@@ -22,8 +24,10 @@ module control4mo(
         .clk(clk),
         .rst(rst),
         .instr_in(instr_in),
+        .instr_set_in(instr_set_in),
         .pc_in(stage_pc),
         .instr_out(instr_out),
+        .instr_set_out(instr_set_out),
         .pc_out(pc_out)
     );
 endmodule

--- a/src/control5ra.v
+++ b/src/control5ra.v
@@ -4,8 +4,10 @@ module control5ra(
     input  wire        rst,
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     output wire [11:0] pc_out,
-    output wire [11:0] instr_out
+    output wire [11:0] instr_out,
+    output wire [3:0]  instr_set_out
 );
     wire [11:0] stage_pc;
 
@@ -22,8 +24,10 @@ module control5ra(
         .clk(clk),
         .rst(rst),
         .instr_in(instr_in),
+        .instr_set_in(instr_set_in),
         .pc_in(stage_pc),
         .instr_out(instr_out),
+        .instr_set_out(instr_set_out),
         .pc_out(pc_out)
     );
 endmodule

--- a/src/control5ro.v
+++ b/src/control5ro.v
@@ -4,8 +4,10 @@ module control5ro(
     input  wire        rst,
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     output wire [11:0] pc_out,
-    output wire [11:0] instr_out
+    output wire [11:0] instr_out,
+    output wire [3:0]  instr_set_out
 );
     // Final Register Operation stage
     stage5ro u_stage5ro(
@@ -17,4 +19,5 @@ module control5ro(
 
     // No further stage, so pass instruction through
     assign instr_out = instr_in;
+    assign instr_set_out = instr_set_in;
 endmodule

--- a/src/henad.v
+++ b/src/henad.v
@@ -1,5 +1,6 @@
 // henad.v
 // Top-level Henad 5-stage RISC core
+`include "src/iset.vh"
 module henad(
     input wire clk,
     input wire rst
@@ -25,6 +26,15 @@ module henad(
     wire [11:0] mora_instr;
     wire [11:0] raro_instr;
     wire [11:0] final_instr;
+
+    wire [3:0] ifid_set;
+    // Instruction set value at each pipeline stage
+    wire [3:0] idex_set;
+    wire [3:0] exma_set;
+    wire [3:0] mamo_set;
+    wire [3:0] mora_set;
+    wire [3:0] raro_set;
+    wire [3:0] final_set;
 
     // Update ia_pc every tick when rst is deasserted
     always @(posedge clk or posedge rst) begin
@@ -60,14 +70,19 @@ module henad(
         .data(instr_mem_data)
     );
 
+    // Initial instruction set for the pipeline
+    assign ifid_set = `ISET_BASE;
+
     // ID stage control
     control2id u_control2id(
         .clk(clk),
         .rst(rst),
         .pc_in(ifid_pc),
         .instr_in(ifid_instr),
+        .instr_set_in(ifid_set),
         .pc_out(idex_pc),
-        .instr_out(idex_instr)
+        .instr_out(idex_instr),
+        .instr_set_out(idex_set)
     );
 
     // EX stage control
@@ -76,8 +91,10 @@ module henad(
         .rst(rst),
         .pc_in(idex_pc),
         .instr_in(idex_instr),
+        .instr_set_in(idex_set),
         .pc_out(exma_pc),
-        .instr_out(exma_instr)
+        .instr_out(exma_instr),
+        .instr_set_out(exma_set)
     );
 
     // Memory address stage control
@@ -86,8 +103,10 @@ module henad(
         .rst(rst),
         .pc_in(exma_pc),
         .instr_in(exma_instr),
+        .instr_set_in(exma_set),
         .pc_out(mamo_pc),
-        .instr_out(mamo_instr)
+        .instr_out(mamo_instr),
+        .instr_set_out(mamo_set)
     );
 
     // Memory operation stage control
@@ -96,8 +115,10 @@ module henad(
         .rst(rst),
         .pc_in(mamo_pc),
         .instr_in(mamo_instr),
+        .instr_set_in(mamo_set),
         .pc_out(mora_pc),
-        .instr_out(mora_instr)
+        .instr_out(mora_instr),
+        .instr_set_out(mora_set)
     );
 
     // Register address stage control
@@ -106,8 +127,10 @@ module henad(
         .rst(rst),
         .pc_in(mora_pc),
         .instr_in(mora_instr),
+        .instr_set_in(mora_set),
         .pc_out(raro_pc),
-        .instr_out(raro_instr)
+        .instr_out(raro_instr),
+        .instr_set_out(raro_set)
     );
 
     // Register operation stage control
@@ -116,7 +139,9 @@ module henad(
         .rst(rst),
         .pc_in(raro_pc),
         .instr_in(raro_instr),
+        .instr_set_in(raro_set),
         .pc_out(final_pc),
-        .instr_out(final_instr)
+        .instr_out(final_instr),
+        .instr_set_out(final_set)
     );
 endmodule

--- a/src/latch2idex.v
+++ b/src/latch2idex.v
@@ -1,19 +1,24 @@
 // latch2idex.v
 // Latch between Instruction Decode (ID) and Execute (EX) stages
+`include "src/iset.vh"
 module latch2idex(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     input  wire [11:0] pc_in,
     output reg  [11:0] instr_out,
+    output reg  [3:0]  instr_set_out,
     output reg  [11:0] pc_out
 );
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             instr_out <= 12'b0;
+            instr_set_out <= `ISET_BASE;
             pc_out    <= 12'b0;
         end else begin
             instr_out <= instr_in;
+            instr_set_out <= instr_set_in;
             pc_out    <= pc_in;
         end
     end

--- a/src/latch3exma.v
+++ b/src/latch3exma.v
@@ -1,19 +1,24 @@
 // latch3exma.v
 // Latch between Execute (EX) and Memory Address (MA) stages
+`include "src/iset.vh"
 module latch3exma(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     input  wire [11:0] pc_in,
     output reg  [11:0] instr_out,
+    output reg  [3:0]  instr_set_out,
     output reg  [11:0] pc_out
 );
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             instr_out <= 12'b0;
+            instr_set_out <= `ISET_BASE;
             pc_out    <= 12'b0;
         end else begin
             instr_out <= instr_in;
+            instr_set_out <= instr_set_in;
             pc_out    <= pc_in;
         end
     end

--- a/src/latch4mamo.v
+++ b/src/latch4mamo.v
@@ -1,19 +1,24 @@
 // latch4mamo.v
 // Latch between Memory Address (MA) and Memory Operation (MO) stages
+`include "src/iset.vh"
 module latch4mamo(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     input  wire [11:0] pc_in,
     output reg  [11:0] instr_out,
+    output reg  [3:0]  instr_set_out,
     output reg  [11:0] pc_out
 );
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             instr_out <= 12'b0;
+            instr_set_out <= `ISET_BASE;
             pc_out    <= 12'b0;
         end else begin
             instr_out <= instr_in;
+            instr_set_out <= instr_set_in;
             pc_out    <= pc_in;
         end
     end

--- a/src/latch4mora.v
+++ b/src/latch4mora.v
@@ -1,19 +1,24 @@
 // latch4mora.v
 // Latch between Memory Operation (MO) and Register Address (RA) stages
+`include "src/iset.vh"
 module latch4mora(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     input  wire [11:0] pc_in,
     output reg  [11:0] instr_out,
+    output reg  [3:0]  instr_set_out,
     output reg  [11:0] pc_out
 );
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             instr_out <= 12'b0;
+            instr_set_out <= `ISET_BASE;
             pc_out    <= 12'b0;
         end else begin
             instr_out <= instr_in;
+            instr_set_out <= instr_set_in;
             pc_out    <= pc_in;
         end
     end

--- a/src/latch5raro.v
+++ b/src/latch5raro.v
@@ -1,19 +1,24 @@
 // latch5raro.v
 // Latch between Register Address (RA) and Register Operation (RO) stages
+`include "src/iset.vh"
 module latch5raro(
     input  wire        clk,
     input  wire        rst,
     input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     input  wire [11:0] pc_in,
     output reg  [11:0] instr_out,
+    output reg  [3:0]  instr_set_out,
     output reg  [11:0] pc_out
 );
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             instr_out <= 12'b0;
+            instr_set_out <= `ISET_BASE;
             pc_out    <= 12'b0;
         end else begin
             instr_out <= instr_in;
+            instr_set_out <= instr_set_in;
             pc_out    <= pc_in;
         end
     end

--- a/src/stage2id.v
+++ b/src/stage2id.v
@@ -2,12 +2,26 @@
 // Simple placeholder for the Instruction Decode stage.  The stage
 // currently just passes the program counter through so that each
 // pipeline stage retains its own PC value.
+`include "src/opcodes.vh"
+`include "src/iset.vh"
+
 module stage2id(
     input  wire        clk,
     input  wire        rst,
+    input  wire [11:0] instr_in,
+    input  wire [3:0]  instr_set_in,
     input  wire [11:0] pc_in,
-    output wire [11:0] pc_out
+    output wire [11:0] pc_out,
+    output wire [3:0]  instr_set_out
 );
-    // No decode logic yet.  Simply propagate the PC.
+    // No real decode logic yet.  The instruction set would normally
+    // change when a special "SW" instruction is decoded.  For now the
+    // stage simply passes the current set through, incrementing it when
+    // the opcode matches OPC_SW.  This remains purely combinational.
+
+    wire [3:0] opcode = instr_in[11:8];
+
     assign pc_out = pc_in;
+    assign instr_set_out = (opcode == `OPC_SW) ? instr_set_in + 4'd1
+                                               : instr_set_in;
 endmodule

--- a/src/testbench.v
+++ b/src/testbench.v
@@ -55,6 +55,15 @@ module testbench;
                  uut.mora_instr,
                  uut.raro_instr,
                  uut.final_instr);
+        $display("tick %0d : IFID_set=%h IDEX_set=%h EXMA_set=%h MAMO_set=%h MORA_set=%h RARO_set=%h FINAL_set=%h",
+                 tick,
+                 uut.ifid_set,
+                 uut.idex_set,
+                 uut.exma_set,
+                 uut.mamo_set,
+                 uut.mora_set,
+                 uut.raro_set,
+                 uut.final_set);
         tick = tick + 1;
     end
 endmodule

--- a/test.vvp
+++ b/test.vvp
@@ -8,56 +8,56 @@
 :vpi_module "/usr/lib/x86_64-linux-gnu/ivl/v2005_math.vpi";
 :vpi_module "/usr/lib/x86_64-linux-gnu/ivl/va_math.vpi";
 :vpi_module "/usr/lib/x86_64-linux-gnu/ivl/v2009.vpi";
-S_0x58db7117af20 .scope package, "$unit" "$unit" 2 1;
+S_0x557d8c189900 .scope package, "$unit" "$unit" 2 1;
  .timescale 0 0;
-S_0x58db7117b0b0 .scope module, "controlunit" "controlunit" 3 3;
+S_0x557d8c18ab10 .scope module, "controlunit" "controlunit" 3 3;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
-o0x77b7df0e6018 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711df800_0 .net "clk", 0 0, o0x77b7df0e6018;  0 drivers
-o0x77b7df0e6048 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711de770_0 .net "rst", 0 0, o0x77b7df0e6048;  0 drivers
-S_0x58db7117dfb0 .scope module, "forwardunit" "forwardunit" 4 2;
+o0x7feebde7a018 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c18df00_0 .net "clk", 0 0, o0x7feebde7a018;  0 drivers
+o0x7feebde7a048 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c18cba0_0 .net "rst", 0 0, o0x7feebde7a048;  0 drivers
+S_0x557d8c194e00 .scope module, "forwardunit" "forwardunit" 4 2;
  .timescale 0 0;
-S_0x58db7117e140 .scope module, "hazardunit" "hazardunit" 5 2;
+S_0x557d8c115f20 .scope module, "hazardunit" "hazardunit" 5 2;
  .timescale 0 0;
-S_0x58db71180a90 .scope module, "memdata" "memdata" 6 3;
+S_0x557d8c1160b0 .scope module, "memdata" "memdata" 6 3;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "we";
     .port_info 2 /INPUT 12 "addr";
     .port_info 3 /INPUT 12 "wdata";
     .port_info 4 /OUTPUT 12 "rdata";
-o0x77b7df0e60d8 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
-v0x58db711de840_0 .net "addr", 11 0, o0x77b7df0e60d8;  0 drivers
-o0x77b7df0e6108 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711dd7b0_0 .net "clk", 0 0, o0x77b7df0e6108;  0 drivers
-v0x58db711dd880 .array "mem", 4095 0, 11 0;
-v0x58db711db530_0 .var "rdata", 11 0;
-o0x77b7df0e6168 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
-v0x58db711db600_0 .net "wdata", 11 0, o0x77b7df0e6168;  0 drivers
-o0x77b7df0e6198 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f5f60_0 .net "we", 0 0, o0x77b7df0e6198;  0 drivers
-E_0x58db71140b20 .event posedge, v0x58db711dd7b0_0;
-S_0x58db71180c20 .scope module, "regflag" "regflag" 7 3;
+o0x7feebde7a0d8 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
+v0x557d8c18cc70_0 .net "addr", 11 0, o0x7feebde7a0d8;  0 drivers
+o0x7feebde7a108 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c18b970_0 .net "clk", 0 0, o0x7feebde7a108;  0 drivers
+v0x557d8c18ba40 .array "mem", 4095 0, 11 0;
+v0x557d8c187800_0 .var "rdata", 11 0;
+o0x7feebde7a168 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
+v0x557d8c1878d0_0 .net "wdata", 11 0, o0x7feebde7a168;  0 drivers
+o0x7feebde7a198 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a4890_0 .net "we", 0 0, o0x7feebde7a198;  0 drivers
+E_0x557d8c0dbb20 .event posedge, v0x557d8c18b970_0;
+S_0x557d8c118fb0 .scope module, "regflag" "regflag" 7 3;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 4 "flag_in";
     .port_info 3 /INPUT 1 "we";
     .port_info 4 /OUTPUT 4 "flag_out";
-o0x77b7df0e62b8 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f6100_0 .net "clk", 0 0, o0x77b7df0e62b8;  0 drivers
-o0x77b7df0e62e8 .functor BUFZ 4, C4<zzzz>; HiZ drive
-v0x58db711f61e0_0 .net "flag_in", 3 0, o0x77b7df0e62e8;  0 drivers
-v0x58db711f62c0_0 .var "flag_out", 3 0;
-o0x77b7df0e6348 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f6380_0 .net "rst", 0 0, o0x77b7df0e6348;  0 drivers
-o0x77b7df0e6378 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f6440_0 .net "we", 0 0, o0x77b7df0e6378;  0 drivers
-E_0x58db7117a240 .event posedge, v0x58db711f6380_0, v0x58db711f6100_0;
-S_0x58db711835c0 .scope module, "reggp" "reggp" 8 3;
+o0x7feebde7a2b8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a4a30_0 .net "clk", 0 0, o0x7feebde7a2b8;  0 drivers
+o0x7feebde7a2e8 .functor BUFZ 4, C4<zzzz>; HiZ drive
+v0x557d8c1a4b10_0 .net "flag_in", 3 0, o0x7feebde7a2e8;  0 drivers
+v0x557d8c1a4bf0_0 .var "flag_out", 3 0;
+o0x7feebde7a348 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a4cb0_0 .net "rst", 0 0, o0x7feebde7a348;  0 drivers
+o0x7feebde7a378 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a4d70_0 .net "we", 0 0, o0x7feebde7a378;  0 drivers
+E_0x557d8c115240 .event posedge, v0x557d8c1a4cb0_0, v0x557d8c1a4a30_0;
+S_0x557d8c119140 .scope module, "reggp" "reggp" 8 3;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
@@ -68,124 +68,132 @@ S_0x58db711835c0 .scope module, "reggp" "reggp" 8 3;
     .port_info 6 /INPUT 1 "we";
     .port_info 7 /OUTPUT 12 "rdata1";
     .port_info 8 /OUTPUT 12 "rdata2";
-L_0x58db71205810 .functor BUFZ 12, L_0x58db71205680, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-L_0x58db712059c0 .functor BUFZ 12, L_0x58db71205880, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db711f6630_0 .net *"_ivl_0", 11 0, L_0x58db71205680;  1 drivers
-v0x58db711f6730_0 .net *"_ivl_10", 5 0, L_0x58db71205920;  1 drivers
-L_0x77b7df09d060 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
-v0x58db711f6810_0 .net *"_ivl_13", 1 0, L_0x77b7df09d060;  1 drivers
-v0x58db711f68d0_0 .net *"_ivl_2", 5 0, L_0x58db71205740;  1 drivers
-L_0x77b7df09d018 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
-v0x58db711f69b0_0 .net *"_ivl_5", 1 0, L_0x77b7df09d018;  1 drivers
-v0x58db711f6ae0_0 .net *"_ivl_8", 11 0, L_0x58db71205880;  1 drivers
-o0x77b7df0e65b8 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f6bc0_0 .net "clk", 0 0, o0x77b7df0e65b8;  0 drivers
-v0x58db711f6c80_0 .var/i "i", 31 0;
-o0x77b7df0e6618 .functor BUFZ 4, C4<zzzz>; HiZ drive
-v0x58db711f6d60_0 .net "raddr1", 3 0, o0x77b7df0e6618;  0 drivers
-o0x77b7df0e6648 .functor BUFZ 4, C4<zzzz>; HiZ drive
-v0x58db711f6e40_0 .net "raddr2", 3 0, o0x77b7df0e6648;  0 drivers
-v0x58db711f6f20_0 .net "rdata1", 11 0, L_0x58db71205810;  1 drivers
-v0x58db711f7000_0 .net "rdata2", 11 0, L_0x58db712059c0;  1 drivers
-v0x58db711f70e0 .array "regs", 0 15, 11 0;
-o0x77b7df0e66d8 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f71a0_0 .net "rst", 0 0, o0x77b7df0e66d8;  0 drivers
-o0x77b7df0e6708 .functor BUFZ 4, C4<zzzz>; HiZ drive
-v0x58db711f7260_0 .net "waddr", 3 0, o0x77b7df0e6708;  0 drivers
-o0x77b7df0e6738 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
-v0x58db711f7340_0 .net "wdata", 11 0, o0x77b7df0e6738;  0 drivers
-o0x77b7df0e6768 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f7420_0 .net "we", 0 0, o0x77b7df0e6768;  0 drivers
-E_0x58db711648c0 .event posedge, v0x58db711f71a0_0, v0x58db711f6bc0_0;
-L_0x58db71205680 .array/port v0x58db711f70e0, L_0x58db71205740;
-L_0x58db71205740 .concat [ 4 2 0 0], o0x77b7df0e6618, L_0x77b7df09d018;
-L_0x58db71205880 .array/port v0x58db711f70e0, L_0x58db71205920;
-L_0x58db71205920 .concat [ 4 2 0 0], o0x77b7df0e6648, L_0x77b7df09d060;
-S_0x58db71183830 .scope module, "reglr" "reglr" 9 3;
+L_0x557d8c1935d0 .functor BUFZ 12, L_0x557d8c1b6790, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+L_0x557d8c1b6a30 .functor BUFZ 12, L_0x557d8c1b68f0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1a4f10_0 .net *"_ivl_0", 11 0, L_0x557d8c1b6790;  1 drivers
+v0x557d8c1a5010_0 .net *"_ivl_10", 5 0, L_0x557d8c1b6990;  1 drivers
+L_0x7feebde31060 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x557d8c1a50f0_0 .net *"_ivl_13", 1 0, L_0x7feebde31060;  1 drivers
+v0x557d8c1a51b0_0 .net *"_ivl_2", 5 0, L_0x557d8c1b6850;  1 drivers
+L_0x7feebde31018 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x557d8c1a5290_0 .net *"_ivl_5", 1 0, L_0x7feebde31018;  1 drivers
+v0x557d8c1a5370_0 .net *"_ivl_8", 11 0, L_0x557d8c1b68f0;  1 drivers
+o0x7feebde7a5b8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a5450_0 .net "clk", 0 0, o0x7feebde7a5b8;  0 drivers
+v0x557d8c1a5510_0 .var/i "i", 31 0;
+o0x7feebde7a618 .functor BUFZ 4, C4<zzzz>; HiZ drive
+v0x557d8c1a55f0_0 .net "raddr1", 3 0, o0x7feebde7a618;  0 drivers
+o0x7feebde7a648 .functor BUFZ 4, C4<zzzz>; HiZ drive
+v0x557d8c1a56d0_0 .net "raddr2", 3 0, o0x7feebde7a648;  0 drivers
+v0x557d8c1a57b0_0 .net "rdata1", 11 0, L_0x557d8c1935d0;  1 drivers
+v0x557d8c1a5890_0 .net "rdata2", 11 0, L_0x557d8c1b6a30;  1 drivers
+v0x557d8c1a5970 .array "regs", 0 15, 11 0;
+o0x7feebde7a6d8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a5a30_0 .net "rst", 0 0, o0x7feebde7a6d8;  0 drivers
+o0x7feebde7a708 .functor BUFZ 4, C4<zzzz>; HiZ drive
+v0x557d8c1a5af0_0 .net "waddr", 3 0, o0x7feebde7a708;  0 drivers
+o0x7feebde7a738 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
+v0x557d8c1a5bd0_0 .net "wdata", 11 0, o0x7feebde7a738;  0 drivers
+o0x7feebde7a768 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a5cb0_0 .net "we", 0 0, o0x7feebde7a768;  0 drivers
+E_0x557d8c0ff8c0 .event posedge, v0x557d8c1a5a30_0, v0x557d8c1a5450_0;
+L_0x557d8c1b6790 .array/port v0x557d8c1a5970, L_0x557d8c1b6850;
+L_0x557d8c1b6850 .concat [ 4 2 0 0], o0x7feebde7a618, L_0x7feebde31018;
+L_0x557d8c1b68f0 .array/port v0x557d8c1a5970, L_0x557d8c1b6990;
+L_0x557d8c1b6990 .concat [ 4 2 0 0], o0x7feebde7a648, L_0x7feebde31060;
+S_0x557d8c11ca70 .scope module, "reglr" "reglr" 9 3;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "lr_in";
     .port_info 3 /INPUT 1 "we";
     .port_info 4 /OUTPUT 12 "lr_out";
-o0x77b7df0e6948 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f7640_0 .net "clk", 0 0, o0x77b7df0e6948;  0 drivers
-o0x77b7df0e6978 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
-v0x58db711f7720_0 .net "lr_in", 11 0, o0x77b7df0e6978;  0 drivers
-v0x58db711f7800_0 .var "lr_out", 11 0;
-o0x77b7df0e69d8 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f78c0_0 .net "rst", 0 0, o0x77b7df0e69d8;  0 drivers
-o0x77b7df0e6a08 .functor BUFZ 1, C4<z>; HiZ drive
-v0x58db711f7980_0 .net "we", 0 0, o0x77b7df0e6a08;  0 drivers
-E_0x58db711e4150 .event posedge, v0x58db711f78c0_0, v0x58db711f7640_0;
-S_0x58db711860f0 .scope module, "testbench" "testbench" 10 8;
+o0x7feebde7a948 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a5ed0_0 .net "clk", 0 0, o0x7feebde7a948;  0 drivers
+o0x7feebde7a978 .functor BUFZ 12, C4<zzzzzzzzzzzz>; HiZ drive
+v0x557d8c1a5fb0_0 .net "lr_in", 11 0, o0x7feebde7a978;  0 drivers
+v0x557d8c1a6090_0 .var "lr_out", 11 0;
+o0x7feebde7a9d8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a6150_0 .net "rst", 0 0, o0x7feebde7a9d8;  0 drivers
+o0x7feebde7aa08 .functor BUFZ 1, C4<z>; HiZ drive
+v0x557d8c1a6210_0 .net "we", 0 0, o0x7feebde7aa08;  0 drivers
+E_0x557d8c193640 .event posedge, v0x557d8c1a6150_0, v0x557d8c1a5ed0_0;
+S_0x557d8c11cc00 .scope module, "testbench" "testbench" 10 8;
  .timescale -9 -12;
-v0x58db71205480_0 .var "clk", 0 0;
-v0x58db71205520_0 .var "rst", 0 0;
-v0x58db712055e0_0 .var/i "tick", 31 0;
-S_0x58db711f7ae0 .scope module, "uut" "henad" 10 14, 11 3 0, S_0x58db711860f0;
+v0x557d8c1b6590_0 .var "clk", 0 0;
+v0x557d8c1b6630_0 .var "rst", 0 0;
+v0x557d8c1b66f0_0 .var/i "tick", 31 0;
+S_0x557d8c1a6370 .scope module, "uut" "henad" 10 14, 11 4 0, S_0x557d8c11cc00;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
-v0x58db71203f20_0 .net "clk", 0 0, v0x58db71205480_0;  1 drivers
-v0x58db71203fc0_0 .net "exma_instr", 11 0, v0x58db711fccd0_0;  1 drivers
-v0x58db71204080_0 .net "exma_pc", 11 0, v0x58db711fce70_0;  1 drivers
-v0x58db712041b0_0 .net "final_instr", 11 0, L_0x58db71206140;  1 drivers
-v0x58db71204270_0 .net "final_pc", 11 0, L_0x58db71206090;  1 drivers
-v0x58db71204310_0 .var "ia_pc", 11 0;
-v0x58db71204420_0 .net "iaif_pc", 11 0, v0x58db711f8340_0;  1 drivers
-v0x58db71204570_0 .net "idex_instr", 11 0, v0x58db711fb450_0;  1 drivers
-v0x58db712046c0_0 .net "idex_pc", 11 0, v0x58db711fb5f0_0;  1 drivers
-v0x58db712048a0_0 .net "ifid_instr", 11 0, v0x58db711f99f0_0;  1 drivers
-v0x58db712049f0_0 .net "ifid_pc", 11 0, v0x58db711f9b90_0;  1 drivers
-v0x58db71204b40_0 .net "instr_mem_addr", 11 0, L_0x58db71205aa0;  1 drivers
-v0x58db71204c00_0 .net "instr_mem_data", 11 0, v0x58db71203d10_0;  1 drivers
-v0x58db71204cc0_0 .net "mamo_instr", 11 0, v0x58db711fe490_0;  1 drivers
-v0x58db71204e10_0 .net "mamo_pc", 11 0, v0x58db711fe630_0;  1 drivers
-v0x58db71204f60_0 .net "mora_instr", 11 0, v0x58db711ffbd0_0;  1 drivers
-v0x58db712050b0_0 .net "mora_pc", 11 0, v0x58db711ffd70_0;  1 drivers
-v0x58db71205170_0 .net "raro_instr", 11 0, v0x58db71201760_0;  1 drivers
-v0x58db71205230_0 .net "raro_pc", 11 0, v0x58db71201900_0;  1 drivers
-v0x58db71205380_0 .net "rst", 0 0, v0x58db71205520_0;  1 drivers
-S_0x58db711f7d00 .scope module, "u_control1ia" "control1ia" 11 40, 12 2 0, S_0x58db711f7ae0;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "rst";
-    .port_info 2 /INPUT 12 "pc_in";
-    .port_info 3 /OUTPUT 12 "pc_out";
-    .port_info 4 /OUTPUT 12 "mem_addr";
-v0x58db711f8c90_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711f8da0_0 .net "mem_addr", 11 0, L_0x58db71205aa0;  alias, 1 drivers
-v0x58db711f8e60_0 .net "pc_in", 11 0, v0x58db71204310_0;  1 drivers
-v0x58db711f8f30_0 .net "pc_out", 11 0, v0x58db711f8340_0;  alias, 1 drivers
-v0x58db711f9000_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db711f9140_0 .net "stage_pc", 11 0, L_0x58db71205a30;  1 drivers
-S_0x58db711f7f00 .scope module, "u_latch1iaif" "latch1iaif" 12 24, 13 2 0, S_0x58db711f7d00;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "rst";
-    .port_info 2 /INPUT 12 "pc_in";
-    .port_info 3 /OUTPUT 12 "pc_out";
-v0x58db711f8180_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711f8260_0 .net "pc_in", 11 0, L_0x58db71205a30;  alias, 1 drivers
-v0x58db711f8340_0 .var "pc_out", 11 0;
-v0x58db711f8430_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-E_0x58db711f8100 .event posedge, v0x58db711f8430_0, v0x58db711f8180_0;
-S_0x58db711f85a0 .scope module, "u_stage1ia" "stage1ia" 12 15, 14 2 0, S_0x58db711f7d00;
+v0x557d8c1b4920_0 .net "clk", 0 0, v0x557d8c1b6590_0;  1 drivers
+v0x557d8c1b49c0_0 .net "exma_instr", 11 0, v0x557d8c1ac280_0;  1 drivers
+v0x557d8c1b4b10_0 .net "exma_pc", 11 0, v0x557d8c1ac660_0;  1 drivers
+v0x557d8c1b4c40_0 .net "exma_set", 3 0, v0x557d8c1ac450_0;  1 drivers
+v0x557d8c1b4d90_0 .net "final_instr", 11 0, L_0x557d8c1b74d0;  1 drivers
+v0x557d8c1b4e50_0 .net "final_pc", 11 0, L_0x557d8c1b7420;  1 drivers
+v0x557d8c1b4ef0_0 .net "final_set", 3 0, L_0x557d8c1b7660;  1 drivers
+v0x557d8c1b4fb0_0 .var "ia_pc", 11 0;
+v0x557d8c1b5050_0 .net "iaif_pc", 11 0, v0x557d8c1a6b30_0;  1 drivers
+v0x557d8c1b5230_0 .net "idex_instr", 11 0, v0x557d8c1a9d00_0;  1 drivers
+v0x557d8c1b5380_0 .net "idex_pc", 11 0, v0x557d8c1aa0b0_0;  1 drivers
+v0x557d8c1b54d0_0 .net "idex_set", 3 0, v0x557d8c1a9ea0_0;  1 drivers
+v0x557d8c1b5620_0 .net "ifid_instr", 11 0, v0x557d8c1a81e0_0;  1 drivers
+v0x557d8c1b56e0_0 .net "ifid_pc", 11 0, v0x557d8c1a8380_0;  1 drivers
+L_0x7feebde310a8 .functor BUFT 1, C4<0000>, C4<0>, C4<0>, C4<0>;
+v0x557d8c1b5830_0 .net "ifid_set", 3 0, L_0x7feebde310a8;  1 drivers
+v0x557d8c1b58f0_0 .net "instr_mem_addr", 11 0, L_0x557d8c1b6b10;  1 drivers
+v0x557d8c1b59b0_0 .net "instr_mem_data", 11 0, v0x557d8c1b4710_0;  1 drivers
+v0x557d8c1b5a70_0 .net "mamo_instr", 11 0, v0x557d8c1adea0_0;  1 drivers
+v0x557d8c1b5b30_0 .net "mamo_pc", 11 0, v0x557d8c1ae280_0;  1 drivers
+v0x557d8c1b5c80_0 .net "mamo_set", 3 0, v0x557d8c1ae070_0;  1 drivers
+v0x557d8c1b5dd0_0 .net "mora_instr", 11 0, v0x557d8c1afa70_0;  1 drivers
+v0x557d8c1b5f20_0 .net "mora_pc", 11 0, v0x557d8c1afe50_0;  1 drivers
+v0x557d8c1b6070_0 .net "mora_set", 3 0, v0x557d8c1afc40_0;  1 drivers
+v0x557d8c1b61c0_0 .net "raro_instr", 11 0, v0x557d8c1b1a90_0;  1 drivers
+v0x557d8c1b6280_0 .net "raro_pc", 11 0, v0x557d8c1b1e70_0;  1 drivers
+v0x557d8c1b63d0_0 .net "raro_set", 3 0, v0x557d8c1b1c60_0;  1 drivers
+v0x557d8c1b6490_0 .net "rst", 0 0, v0x557d8c1b6630_0;  1 drivers
+S_0x557d8c1a6540 .scope module, "u_control1ia" "control1ia" 11 50, 12 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /OUTPUT 12 "pc_out";
     .port_info 4 /OUTPUT 12 "mem_addr";
-L_0x58db71205a30 .functor BUFZ 12, v0x58db71204310_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-L_0x58db71205aa0 .functor BUFZ 12, v0x58db71204310_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db711f87a0_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711f8870_0 .net "mem_addr", 11 0, L_0x58db71205aa0;  alias, 1 drivers
-v0x58db711f8930_0 .net "pc_in", 11 0, v0x58db71204310_0;  alias, 1 drivers
-v0x58db711f8a20_0 .net "pc_out", 11 0, L_0x58db71205a30;  alias, 1 drivers
-v0x58db711f8b10_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711f92b0 .scope module, "u_control1if" "control1if" 11 49, 15 2 0, S_0x58db711f7ae0;
+v0x557d8c1a7480_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a7590_0 .net "mem_addr", 11 0, L_0x557d8c1b6b10;  alias, 1 drivers
+v0x557d8c1a7650_0 .net "pc_in", 11 0, v0x557d8c1b4fb0_0;  1 drivers
+v0x557d8c1a7720_0 .net "pc_out", 11 0, v0x557d8c1a6b30_0;  alias, 1 drivers
+v0x557d8c1a77f0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1a7930_0 .net "stage_pc", 11 0, L_0x557d8c1b6aa0;  1 drivers
+S_0x557d8c1a66f0 .scope module, "u_latch1iaif" "latch1iaif" 12 24, 13 2 0, S_0x557d8c1a6540;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /INPUT 12 "pc_in";
+    .port_info 3 /OUTPUT 12 "pc_out";
+v0x557d8c1a6970_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a6a50_0 .net "pc_in", 11 0, L_0x557d8c1b6aa0;  alias, 1 drivers
+v0x557d8c1a6b30_0 .var "pc_out", 11 0;
+v0x557d8c1a6c20_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+E_0x557d8c1a68f0 .event posedge, v0x557d8c1a6c20_0, v0x557d8c1a6970_0;
+S_0x557d8c1a6d90 .scope module, "u_stage1ia" "stage1ia" 12 15, 14 2 0, S_0x557d8c1a6540;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /INPUT 12 "pc_in";
+    .port_info 3 /OUTPUT 12 "pc_out";
+    .port_info 4 /OUTPUT 12 "mem_addr";
+L_0x557d8c1b6aa0 .functor BUFZ 12, v0x557d8c1b4fb0_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+L_0x557d8c1b6b10 .functor BUFZ 12, v0x557d8c1b4fb0_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1a6f90_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a7060_0 .net "mem_addr", 11 0, L_0x557d8c1b6b10;  alias, 1 drivers
+v0x557d8c1a7120_0 .net "pc_in", 11 0, v0x557d8c1b4fb0_0;  alias, 1 drivers
+v0x557d8c1a7210_0 .net "pc_out", 11 0, L_0x557d8c1b6aa0;  alias, 1 drivers
+v0x557d8c1a7300_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1a7aa0 .scope module, "u_control1if" "control1if" 11 59, 15 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
@@ -193,15 +201,15 @@ S_0x58db711f92b0 .scope module, "u_control1if" "control1if" 11 49, 15 2 0, S_0x5
     .port_info 3 /OUTPUT 12 "pc_out";
     .port_info 4 /OUTPUT 12 "instr_out";
     .port_info 5 /INPUT 12 "instr_mem_data";
-v0x58db711fa650_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fa710_0 .net "instr_mem_data", 11 0, v0x58db71203d10_0;  alias, 1 drivers
-v0x58db711fa7d0_0 .net "instr_out", 11 0, v0x58db711f99f0_0;  alias, 1 drivers
-v0x58db711fa8a0_0 .net "pc_in", 11 0, v0x58db711f8340_0;  alias, 1 drivers
-v0x58db711fa940_0 .net "pc_out", 11 0, v0x58db711f9b90_0;  alias, 1 drivers
-v0x58db711fa9e0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db711faa80_0 .net "stage_instr", 11 0, L_0x58db71205ca0;  1 drivers
-v0x58db711fab70_0 .net "stage_pc", 11 0, L_0x58db71205c30;  1 drivers
-S_0x58db711f9590 .scope module, "u_latch1ifid" "latch1ifid" 15 23, 16 2 0, S_0x58db711f92b0;
+v0x557d8c1a8e40_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a8f00_0 .net "instr_mem_data", 11 0, v0x557d8c1b4710_0;  alias, 1 drivers
+v0x557d8c1a8fc0_0 .net "instr_out", 11 0, v0x557d8c1a81e0_0;  alias, 1 drivers
+v0x557d8c1a9090_0 .net "pc_in", 11 0, v0x557d8c1a6b30_0;  alias, 1 drivers
+v0x557d8c1a9130_0 .net "pc_out", 11 0, v0x557d8c1a8380_0;  alias, 1 drivers
+v0x557d8c1a91d0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1a9270_0 .net "stage_instr", 11 0, L_0x557d8c1b6d10;  1 drivers
+v0x557d8c1a9360_0 .net "stage_pc", 11 0, L_0x557d8c1b6ca0;  1 drivers
+S_0x557d8c1a7d80 .scope module, "u_latch1ifid" "latch1ifid" 15 23, 16 2 0, S_0x557d8c1a7aa0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
@@ -209,13 +217,13 @@ S_0x58db711f9590 .scope module, "u_latch1ifid" "latch1ifid" 15 23, 16 2 0, S_0x5
     .port_info 3 /INPUT 12 "pc_in";
     .port_info 4 /OUTPUT 12 "instr_out";
     .port_info 5 /OUTPUT 12 "pc_out";
-v0x58db711f9850_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711f9910_0 .net "instr_in", 11 0, L_0x58db71205ca0;  alias, 1 drivers
-v0x58db711f99f0_0 .var "instr_out", 11 0;
-v0x58db711f9ab0_0 .net "pc_in", 11 0, L_0x58db71205c30;  alias, 1 drivers
-v0x58db711f9b90_0 .var "pc_out", 11 0;
-v0x58db711f9cc0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711f9e60 .scope module, "u_stage1if" "stage1if" 15 14, 17 2 0, S_0x58db711f92b0;
+v0x557d8c1a8040_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a8100_0 .net "instr_in", 11 0, L_0x557d8c1b6d10;  alias, 1 drivers
+v0x557d8c1a81e0_0 .var "instr_out", 11 0;
+v0x557d8c1a82a0_0 .net "pc_in", 11 0, L_0x557d8c1b6ca0;  alias, 1 drivers
+v0x557d8c1a8380_0 .var "pc_out", 11 0;
+v0x557d8c1a84b0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1a8650 .scope module, "u_stage1if" "stage1if" 15 14, 17 2 0, S_0x557d8c1a7aa0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
@@ -223,555 +231,638 @@ S_0x58db711f9e60 .scope module, "u_stage1if" "stage1if" 15 14, 17 2 0, S_0x58db7
     .port_info 3 /INPUT 12 "pc_in";
     .port_info 4 /OUTPUT 12 "pc_out";
     .port_info 5 /OUTPUT 12 "instr_out";
-L_0x58db71205c30 .functor BUFZ 12, v0x58db711f8340_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-L_0x58db71205ca0 .functor BUFZ 12, v0x58db71203d10_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db711fa100_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fa1a0_0 .net "instr_mem_data", 11 0, v0x58db71203d10_0;  alias, 1 drivers
-v0x58db711fa280_0 .net "instr_out", 11 0, L_0x58db71205ca0;  alias, 1 drivers
-v0x58db711fa320_0 .net "pc_in", 11 0, v0x58db711f8340_0;  alias, 1 drivers
-v0x58db711fa3c0_0 .net "pc_out", 11 0, L_0x58db71205c30;  alias, 1 drivers
-v0x58db711fa4d0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711fad40 .scope module, "u_control2id" "control2id" 11 64, 18 2 0, S_0x58db711f7ae0;
+L_0x557d8c1b6ca0 .functor BUFZ 12, v0x557d8c1a6b30_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+L_0x557d8c1b6d10 .functor BUFZ 12, v0x557d8c1b4710_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1a88f0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a8990_0 .net "instr_mem_data", 11 0, v0x557d8c1b4710_0;  alias, 1 drivers
+v0x557d8c1a8a70_0 .net "instr_out", 11 0, L_0x557d8c1b6d10;  alias, 1 drivers
+v0x557d8c1a8b10_0 .net "pc_in", 11 0, v0x557d8c1a6b30_0;  alias, 1 drivers
+v0x557d8c1a8bb0_0 .net "pc_out", 11 0, L_0x557d8c1b6ca0;  alias, 1 drivers
+v0x557d8c1a8cc0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1a9530 .scope module, "u_control2id" "control2id" 11 77, 18 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /INPUT 12 "instr_in";
-    .port_info 4 /OUTPUT 12 "pc_out";
-    .port_info 5 /OUTPUT 12 "instr_out";
-v0x58db711fbe40_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fbf00_0 .net "instr_in", 11 0, v0x58db711f99f0_0;  alias, 1 drivers
-v0x58db711fbfc0_0 .net "instr_out", 11 0, v0x58db711fb450_0;  alias, 1 drivers
-v0x58db711fc090_0 .net "pc_in", 11 0, v0x58db711f9b90_0;  alias, 1 drivers
-v0x58db711fc130_0 .net "pc_out", 11 0, v0x58db711fb5f0_0;  alias, 1 drivers
-v0x58db711fc240_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db711fc3f0_0 .net "stage_pc", 11 0, L_0x58db71205da0;  1 drivers
-S_0x58db711fafc0 .scope module, "u_latch2idex" "latch2idex" 18 22, 19 3 0, S_0x58db711fad40;
+    .port_info 4 /INPUT 4 "instr_set_in";
+    .port_info 5 /OUTPUT 12 "pc_out";
+    .port_info 6 /OUTPUT 12 "instr_out";
+    .port_info 7 /OUTPUT 4 "instr_set_out";
+v0x557d8c1ab0e0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1ab1a0_0 .net "instr_in", 11 0, v0x557d8c1a81e0_0;  alias, 1 drivers
+v0x557d8c1ab260_0 .net "instr_out", 11 0, v0x557d8c1a9d00_0;  alias, 1 drivers
+v0x557d8c1ab330_0 .net "instr_set_in", 3 0, L_0x7feebde310a8;  alias, 1 drivers
+v0x557d8c1ab400_0 .net "instr_set_out", 3 0, v0x557d8c1a9ea0_0;  alias, 1 drivers
+v0x557d8c1ab4a0_0 .net "pc_in", 11 0, v0x557d8c1a8380_0;  alias, 1 drivers
+v0x557d8c1ab540_0 .net "pc_out", 11 0, v0x557d8c1aa0b0_0;  alias, 1 drivers
+v0x557d8c1ab630_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1ab7e0_0 .net "stage_pc", 11 0, L_0x557d8c1b6eb0;  1 drivers
+v0x557d8c1ab880_0 .net "stage_set", 3 0, L_0x557d8c1b7190;  1 drivers
+S_0x557d8c1a9830 .scope module, "u_latch2idex" "latch2idex" 18 29, 19 4 0, S_0x557d8c1a9530;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "instr_in";
-    .port_info 3 /INPUT 12 "pc_in";
-    .port_info 4 /OUTPUT 12 "instr_out";
-    .port_info 5 /OUTPUT 12 "pc_out";
-v0x58db711fb280_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fb340_0 .net "instr_in", 11 0, v0x58db711f99f0_0;  alias, 1 drivers
-v0x58db711fb450_0 .var "instr_out", 11 0;
-v0x58db711fb510_0 .net "pc_in", 11 0, L_0x58db71205da0;  alias, 1 drivers
-v0x58db711fb5f0_0 .var "pc_out", 11 0;
-v0x58db711fb720_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711fb8c0 .scope module, "u_stage2id" "stage2id" 18 14, 20 5 0, S_0x58db711fad40;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "rst";
-    .port_info 2 /INPUT 12 "pc_in";
-    .port_info 3 /OUTPUT 12 "pc_out";
-L_0x58db71205da0 .functor BUFZ 12, v0x58db711f9b90_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db711fbac0_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fbb60_0 .net "pc_in", 11 0, v0x58db711f9b90_0;  alias, 1 drivers
-v0x58db711fbc70_0 .net "pc_out", 11 0, L_0x58db71205da0;  alias, 1 drivers
-v0x58db711fbd10_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711fc5a0 .scope module, "u_control3ex" "control3ex" 11 74, 21 2 0, S_0x58db711f7ae0;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "rst";
-    .port_info 2 /INPUT 12 "pc_in";
-    .port_info 3 /INPUT 12 "instr_in";
-    .port_info 4 /OUTPUT 12 "pc_out";
+    .port_info 3 /INPUT 4 "instr_set_in";
+    .port_info 4 /INPUT 12 "pc_in";
     .port_info 5 /OUTPUT 12 "instr_out";
-v0x58db711fd6c0_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fd780_0 .net "instr_in", 11 0, v0x58db711fb450_0;  alias, 1 drivers
-v0x58db711fd840_0 .net "instr_out", 11 0, v0x58db711fccd0_0;  alias, 1 drivers
-v0x58db711fd910_0 .net "pc_in", 11 0, v0x58db711fb5f0_0;  alias, 1 drivers
-v0x58db711fd9b0_0 .net "pc_out", 11 0, v0x58db711fce70_0;  alias, 1 drivers
-v0x58db711fdac0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db711fdb60_0 .net "stage_pc", 11 0, L_0x58db71205e10;  1 drivers
-S_0x58db711fc820 .scope module, "u_latch3exma" "latch3exma" 21 21, 22 3 0, S_0x58db711fc5a0;
+    .port_info 6 /OUTPUT 4 "instr_set_out";
+    .port_info 7 /OUTPUT 12 "pc_out";
+v0x557d8c1a9b30_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1a9bf0_0 .net "instr_in", 11 0, v0x557d8c1a81e0_0;  alias, 1 drivers
+v0x557d8c1a9d00_0 .var "instr_out", 11 0;
+v0x557d8c1a9dc0_0 .net "instr_set_in", 3 0, L_0x557d8c1b7190;  alias, 1 drivers
+v0x557d8c1a9ea0_0 .var "instr_set_out", 3 0;
+v0x557d8c1a9fd0_0 .net "pc_in", 11 0, L_0x557d8c1b6eb0;  alias, 1 drivers
+v0x557d8c1aa0b0_0 .var "pc_out", 11 0;
+v0x557d8c1aa190_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1aa380 .scope module, "u_stage2id" "stage2id" 18 18, 20 8 0, S_0x557d8c1a9530;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "instr_in";
-    .port_info 3 /INPUT 12 "pc_in";
-    .port_info 4 /OUTPUT 12 "instr_out";
+    .port_info 3 /INPUT 4 "instr_set_in";
+    .port_info 4 /INPUT 12 "pc_in";
     .port_info 5 /OUTPUT 12 "pc_out";
-v0x58db711fcb00_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fcbc0_0 .net "instr_in", 11 0, v0x58db711fb450_0;  alias, 1 drivers
-v0x58db711fccd0_0 .var "instr_out", 11 0;
-v0x58db711fcd90_0 .net "pc_in", 11 0, L_0x58db71205e10;  alias, 1 drivers
-v0x58db711fce70_0 .var "pc_out", 11 0;
-v0x58db711fcfa0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711fd140 .scope module, "u_stage3ex" "stage3ex" 21 13, 23 4 0, S_0x58db711fc5a0;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "rst";
-    .port_info 2 /INPUT 12 "pc_in";
-    .port_info 3 /OUTPUT 12 "pc_out";
-L_0x58db71205e10 .functor BUFZ 12, v0x58db711fb5f0_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db711fd340_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fd3e0_0 .net "pc_in", 11 0, v0x58db711fb5f0_0;  alias, 1 drivers
-v0x58db711fd4f0_0 .net "pc_out", 11 0, L_0x58db71205e10;  alias, 1 drivers
-v0x58db711fd590_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711fdd10 .scope module, "u_control4ma" "control4ma" 11 84, 24 2 0, S_0x58db711f7ae0;
+    .port_info 6 /OUTPUT 4 "instr_set_out";
+L_0x557d8c1b6eb0 .functor BUFZ 12, v0x557d8c1a8380_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1aa5e0_0 .net *"_ivl_10", 3 0, L_0x557d8c1b6ff0;  1 drivers
+L_0x7feebde310f0 .functor BUFT 1, C4<0001>, C4<0>, C4<0>, C4<0>;
+v0x557d8c1aa6c0_0 .net/2u *"_ivl_4", 3 0, L_0x7feebde310f0;  1 drivers
+v0x557d8c1aa7a0_0 .net *"_ivl_6", 0 0, L_0x557d8c1b6f20;  1 drivers
+L_0x7feebde31138 .functor BUFT 1, C4<0001>, C4<0>, C4<0>, C4<0>;
+v0x557d8c1aa840_0 .net/2u *"_ivl_8", 3 0, L_0x7feebde31138;  1 drivers
+v0x557d8c1aa920_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1aaa10_0 .net "instr_in", 11 0, v0x557d8c1a81e0_0;  alias, 1 drivers
+v0x557d8c1aaad0_0 .net "instr_set_in", 3 0, L_0x7feebde310a8;  alias, 1 drivers
+v0x557d8c1aabb0_0 .net "instr_set_out", 3 0, L_0x557d8c1b7190;  alias, 1 drivers
+v0x557d8c1aac70_0 .net "opcode", 3 0, L_0x557d8c1b6e10;  1 drivers
+v0x557d8c1aadc0_0 .net "pc_in", 11 0, v0x557d8c1a8380_0;  alias, 1 drivers
+v0x557d8c1aae80_0 .net "pc_out", 11 0, L_0x557d8c1b6eb0;  alias, 1 drivers
+v0x557d8c1aaf40_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+L_0x557d8c1b6e10 .part v0x557d8c1a81e0_0, 8, 4;
+L_0x557d8c1b6f20 .cmp/eq 4, L_0x557d8c1b6e10, L_0x7feebde310f0;
+L_0x557d8c1b6ff0 .arith/sum 4, L_0x7feebde310a8, L_0x7feebde31138;
+L_0x557d8c1b7190 .functor MUXZ 4, L_0x7feebde310a8, L_0x557d8c1b6ff0, L_0x557d8c1b6f20, C4<>;
+S_0x557d8c1abae0 .scope module, "u_control3ex" "control3ex" 11 89, 21 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /INPUT 12 "instr_in";
-    .port_info 4 /OUTPUT 12 "pc_out";
-    .port_info 5 /OUTPUT 12 "instr_out";
-v0x58db711fee50_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fef10_0 .net "instr_in", 11 0, v0x58db711fccd0_0;  alias, 1 drivers
-v0x58db711fefd0_0 .net "instr_out", 11 0, v0x58db711fe490_0;  alias, 1 drivers
-v0x58db711ff0a0_0 .net "pc_in", 11 0, v0x58db711fce70_0;  alias, 1 drivers
-v0x58db711ff140_0 .net "pc_out", 11 0, v0x58db711fe630_0;  alias, 1 drivers
-v0x58db711ff250_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db711ff2f0_0 .net "stage_pc", 11 0, L_0x58db71205e80;  1 drivers
-S_0x58db711fdfe0 .scope module, "u_latch4mamo" "latch4mamo" 24 21, 25 3 0, S_0x58db711fdd10;
+    .port_info 4 /INPUT 4 "instr_set_in";
+    .port_info 5 /OUTPUT 12 "pc_out";
+    .port_info 6 /OUTPUT 12 "instr_out";
+    .port_info 7 /OUTPUT 4 "instr_set_out";
+v0x557d8c1ace30_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1acef0_0 .net "instr_in", 11 0, v0x557d8c1a9d00_0;  alias, 1 drivers
+v0x557d8c1acfb0_0 .net "instr_out", 11 0, v0x557d8c1ac280_0;  alias, 1 drivers
+v0x557d8c1ad050_0 .net "instr_set_in", 3 0, v0x557d8c1a9ea0_0;  alias, 1 drivers
+v0x557d8c1ad0f0_0 .net "instr_set_out", 3 0, v0x557d8c1ac450_0;  alias, 1 drivers
+v0x557d8c1ad200_0 .net "pc_in", 11 0, v0x557d8c1aa0b0_0;  alias, 1 drivers
+v0x557d8c1ad2a0_0 .net "pc_out", 11 0, v0x557d8c1ac660_0;  alias, 1 drivers
+v0x557d8c1ad390_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1ad430_0 .net "stage_pc", 11 0, L_0x557d8c1b7090;  1 drivers
+S_0x557d8c1abd90 .scope module, "u_latch3exma" "latch3exma" 21 24, 22 4 0, S_0x557d8c1abae0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "instr_in";
-    .port_info 3 /INPUT 12 "pc_in";
-    .port_info 4 /OUTPUT 12 "instr_out";
-    .port_info 5 /OUTPUT 12 "pc_out";
-v0x58db711fe2c0_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711fe380_0 .net "instr_in", 11 0, v0x58db711fccd0_0;  alias, 1 drivers
-v0x58db711fe490_0 .var "instr_out", 11 0;
-v0x58db711fe550_0 .net "pc_in", 11 0, L_0x58db71205e80;  alias, 1 drivers
-v0x58db711fe630_0 .var "pc_out", 11 0;
-v0x58db711fe760_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711fe900 .scope module, "u_stage4ma" "stage4ma" 24 13, 26 5 0, S_0x58db711fdd10;
+    .port_info 3 /INPUT 4 "instr_set_in";
+    .port_info 4 /INPUT 12 "pc_in";
+    .port_info 5 /OUTPUT 12 "instr_out";
+    .port_info 6 /OUTPUT 4 "instr_set_out";
+    .port_info 7 /OUTPUT 12 "pc_out";
+v0x557d8c1ac0b0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1ac170_0 .net "instr_in", 11 0, v0x557d8c1a9d00_0;  alias, 1 drivers
+v0x557d8c1ac280_0 .var "instr_out", 11 0;
+v0x557d8c1ac340_0 .net "instr_set_in", 3 0, v0x557d8c1a9ea0_0;  alias, 1 drivers
+v0x557d8c1ac450_0 .var "instr_set_out", 3 0;
+v0x557d8c1ac580_0 .net "pc_in", 11 0, L_0x557d8c1b7090;  alias, 1 drivers
+v0x557d8c1ac660_0 .var "pc_out", 11 0;
+v0x557d8c1ac740_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1ac930 .scope module, "u_stage3ex" "stage3ex" 21 16, 23 4 0, S_0x557d8c1abae0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /OUTPUT 12 "pc_out";
-L_0x58db71205e80 .functor BUFZ 12, v0x58db711fce70_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db711feb00_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711feba0_0 .net "pc_in", 11 0, v0x58db711fce70_0;  alias, 1 drivers
-v0x58db711fecb0_0 .net "pc_out", 11 0, L_0x58db71205e80;  alias, 1 drivers
-v0x58db711fed50_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db711ff4a0 .scope module, "u_control4mo" "control4mo" 11 94, 27 2 0, S_0x58db711f7ae0;
+L_0x557d8c1b7090 .functor BUFZ 12, v0x557d8c1aa0b0_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1acae0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1acb80_0 .net "pc_in", 11 0, v0x557d8c1aa0b0_0;  alias, 1 drivers
+v0x557d8c1acc90_0 .net "pc_out", 11 0, L_0x557d8c1b7090;  alias, 1 drivers
+v0x557d8c1acd30_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1ad6b0 .scope module, "u_control4ma" "control4ma" 11 101, 24 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /INPUT 12 "instr_in";
-    .port_info 4 /OUTPUT 12 "pc_out";
-    .port_info 5 /OUTPUT 12 "instr_out";
-v0x58db712009e0_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db71200aa0_0 .net "instr_in", 11 0, v0x58db711fe490_0;  alias, 1 drivers
-v0x58db71200b60_0 .net "instr_out", 11 0, v0x58db711ffbd0_0;  alias, 1 drivers
-v0x58db71200c30_0 .net "pc_in", 11 0, v0x58db711fe630_0;  alias, 1 drivers
-v0x58db71200cd0_0 .net "pc_out", 11 0, v0x58db711ffd70_0;  alias, 1 drivers
-v0x58db71200de0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db71200e80_0 .net "stage_pc", 11 0, L_0x58db71205f30;  1 drivers
-S_0x58db711ff720 .scope module, "u_latch4mora" "latch4mora" 27 21, 28 3 0, S_0x58db711ff4a0;
+    .port_info 4 /INPUT 4 "instr_set_in";
+    .port_info 5 /OUTPUT 12 "pc_out";
+    .port_info 6 /OUTPUT 12 "instr_out";
+    .port_info 7 /OUTPUT 4 "instr_set_out";
+v0x557d8c1aea50_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1aeb10_0 .net "instr_in", 11 0, v0x557d8c1ac280_0;  alias, 1 drivers
+v0x557d8c1aebd0_0 .net "instr_out", 11 0, v0x557d8c1adea0_0;  alias, 1 drivers
+v0x557d8c1aec70_0 .net "instr_set_in", 3 0, v0x557d8c1ac450_0;  alias, 1 drivers
+v0x557d8c1aed10_0 .net "instr_set_out", 3 0, v0x557d8c1ae070_0;  alias, 1 drivers
+v0x557d8c1aee20_0 .net "pc_in", 11 0, v0x557d8c1ac660_0;  alias, 1 drivers
+v0x557d8c1aeec0_0 .net "pc_out", 11 0, v0x557d8c1ae280_0;  alias, 1 drivers
+v0x557d8c1aefb0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1af050_0 .net "stage_pc", 11 0, L_0x557d8c1b72b0;  1 drivers
+S_0x557d8c1ad9b0 .scope module, "u_latch4mamo" "latch4mamo" 24 23, 25 4 0, S_0x557d8c1ad6b0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "instr_in";
-    .port_info 3 /INPUT 12 "pc_in";
-    .port_info 4 /OUTPUT 12 "instr_out";
-    .port_info 5 /OUTPUT 12 "pc_out";
-v0x58db711ffa00_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db711ffac0_0 .net "instr_in", 11 0, v0x58db711fe490_0;  alias, 1 drivers
-v0x58db711ffbd0_0 .var "instr_out", 11 0;
-v0x58db711ffc90_0 .net "pc_in", 11 0, L_0x58db71205f30;  alias, 1 drivers
-v0x58db711ffd70_0 .var "pc_out", 11 0;
-v0x58db711ffea0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db71200040 .scope module, "u_stage4mo" "stage4mo" 27 13, 29 4 0, S_0x58db711ff4a0;
+    .port_info 3 /INPUT 4 "instr_set_in";
+    .port_info 4 /INPUT 12 "pc_in";
+    .port_info 5 /OUTPUT 12 "instr_out";
+    .port_info 6 /OUTPUT 4 "instr_set_out";
+    .port_info 7 /OUTPUT 12 "pc_out";
+v0x557d8c1adcd0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1add90_0 .net "instr_in", 11 0, v0x557d8c1ac280_0;  alias, 1 drivers
+v0x557d8c1adea0_0 .var "instr_out", 11 0;
+v0x557d8c1adf60_0 .net "instr_set_in", 3 0, v0x557d8c1ac450_0;  alias, 1 drivers
+v0x557d8c1ae070_0 .var "instr_set_out", 3 0;
+v0x557d8c1ae1a0_0 .net "pc_in", 11 0, L_0x557d8c1b72b0;  alias, 1 drivers
+v0x557d8c1ae280_0 .var "pc_out", 11 0;
+v0x557d8c1ae360_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1ae550 .scope module, "u_stage4ma" "stage4ma" 24 15, 26 5 0, S_0x557d8c1ad6b0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /OUTPUT 12 "pc_out";
-L_0x58db71205f30 .functor BUFZ 12, v0x58db711fe630_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db71200240_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db712004f0_0 .net "pc_in", 11 0, v0x58db711fe630_0;  alias, 1 drivers
-v0x58db71200600_0 .net "pc_out", 11 0, L_0x58db71205f30;  alias, 1 drivers
-v0x58db712006a0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db71201030 .scope module, "u_control5ra" "control5ra" 11 104, 30 2 0, S_0x58db711f7ae0;
+L_0x557d8c1b72b0 .functor BUFZ 12, v0x557d8c1ac660_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1ae700_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1ae7a0_0 .net "pc_in", 11 0, v0x557d8c1ac660_0;  alias, 1 drivers
+v0x557d8c1ae8b0_0 .net "pc_out", 11 0, L_0x557d8c1b72b0;  alias, 1 drivers
+v0x557d8c1ae950_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1af2d0 .scope module, "u_control4mo" "control4mo" 11 113, 27 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /INPUT 12 "instr_in";
-    .port_info 4 /OUTPUT 12 "pc_out";
-    .port_info 5 /OUTPUT 12 "instr_out";
-v0x58db71202150_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db71202210_0 .net "instr_in", 11 0, v0x58db711ffbd0_0;  alias, 1 drivers
-v0x58db712022d0_0 .net "instr_out", 11 0, v0x58db71201760_0;  alias, 1 drivers
-v0x58db712023a0_0 .net "pc_in", 11 0, v0x58db711ffd70_0;  alias, 1 drivers
-v0x58db71202440_0 .net "pc_out", 11 0, v0x58db71201900_0;  alias, 1 drivers
-v0x58db71202550_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-v0x58db712025f0_0 .net "stage_pc", 11 0, L_0x58db71205fe0;  1 drivers
-S_0x58db712012b0 .scope module, "u_latch5raro" "latch5raro" 30 21, 31 3 0, S_0x58db71201030;
+    .port_info 4 /INPUT 4 "instr_set_in";
+    .port_info 5 /OUTPUT 12 "pc_out";
+    .port_info 6 /OUTPUT 12 "instr_out";
+    .port_info 7 /OUTPUT 4 "instr_set_out";
+v0x557d8c1b0a40_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b0b00_0 .net "instr_in", 11 0, v0x557d8c1adea0_0;  alias, 1 drivers
+v0x557d8c1b0bc0_0 .net "instr_out", 11 0, v0x557d8c1afa70_0;  alias, 1 drivers
+v0x557d8c1b0c90_0 .net "instr_set_in", 3 0, v0x557d8c1ae070_0;  alias, 1 drivers
+v0x557d8c1b0d30_0 .net "instr_set_out", 3 0, v0x557d8c1afc40_0;  alias, 1 drivers
+v0x557d8c1b0e40_0 .net "pc_in", 11 0, v0x557d8c1ae280_0;  alias, 1 drivers
+v0x557d8c1b0ee0_0 .net "pc_out", 11 0, v0x557d8c1afe50_0;  alias, 1 drivers
+v0x557d8c1b0fd0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1b1070_0 .net "stage_pc", 11 0, L_0x557d8c1b7320;  1 drivers
+S_0x557d8c1af580 .scope module, "u_latch4mora" "latch4mora" 27 23, 28 4 0, S_0x557d8c1af2d0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "instr_in";
-    .port_info 3 /INPUT 12 "pc_in";
-    .port_info 4 /OUTPUT 12 "instr_out";
-    .port_info 5 /OUTPUT 12 "pc_out";
-v0x58db71201590_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db71201650_0 .net "instr_in", 11 0, v0x58db711ffbd0_0;  alias, 1 drivers
-v0x58db71201760_0 .var "instr_out", 11 0;
-v0x58db71201820_0 .net "pc_in", 11 0, L_0x58db71205fe0;  alias, 1 drivers
-v0x58db71201900_0 .var "pc_out", 11 0;
-v0x58db71201a30_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db71201bd0 .scope module, "u_stage5ra" "stage5ra" 30 13, 32 4 0, S_0x58db71201030;
+    .port_info 3 /INPUT 4 "instr_set_in";
+    .port_info 4 /INPUT 12 "pc_in";
+    .port_info 5 /OUTPUT 12 "instr_out";
+    .port_info 6 /OUTPUT 4 "instr_set_out";
+    .port_info 7 /OUTPUT 12 "pc_out";
+v0x557d8c1af8a0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1af960_0 .net "instr_in", 11 0, v0x557d8c1adea0_0;  alias, 1 drivers
+v0x557d8c1afa70_0 .var "instr_out", 11 0;
+v0x557d8c1afb30_0 .net "instr_set_in", 3 0, v0x557d8c1ae070_0;  alias, 1 drivers
+v0x557d8c1afc40_0 .var "instr_set_out", 3 0;
+v0x557d8c1afd70_0 .net "pc_in", 11 0, L_0x557d8c1b7320;  alias, 1 drivers
+v0x557d8c1afe50_0 .var "pc_out", 11 0;
+v0x557d8c1aff30_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1b0120 .scope module, "u_stage4mo" "stage4mo" 27 15, 29 4 0, S_0x557d8c1af2d0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /OUTPUT 12 "pc_out";
-L_0x58db71205fe0 .functor BUFZ 12, v0x58db711ffd70_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db71201dd0_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db71201e70_0 .net "pc_in", 11 0, v0x58db711ffd70_0;  alias, 1 drivers
-v0x58db71201f80_0 .net "pc_out", 11 0, L_0x58db71205fe0;  alias, 1 drivers
-v0x58db71202020_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db712027a0 .scope module, "u_control5ro" "control5ro" 11 114, 33 2 0, S_0x58db711f7ae0;
+L_0x557d8c1b7320 .functor BUFZ 12, v0x557d8c1ae280_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1b02d0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b0580_0 .net "pc_in", 11 0, v0x557d8c1ae280_0;  alias, 1 drivers
+v0x557d8c1b0690_0 .net "pc_out", 11 0, L_0x557d8c1b7320;  alias, 1 drivers
+v0x557d8c1b0730_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1b12f0 .scope module, "u_control5ra" "control5ra" 11 125, 30 2 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /INPUT 12 "instr_in";
-    .port_info 4 /OUTPUT 12 "pc_out";
+    .port_info 4 /INPUT 4 "instr_set_in";
+    .port_info 5 /OUTPUT 12 "pc_out";
+    .port_info 6 /OUTPUT 12 "instr_out";
+    .port_info 7 /OUTPUT 4 "instr_set_out";
+v0x557d8c1b2640_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b2700_0 .net "instr_in", 11 0, v0x557d8c1afa70_0;  alias, 1 drivers
+v0x557d8c1b27c0_0 .net "instr_out", 11 0, v0x557d8c1b1a90_0;  alias, 1 drivers
+v0x557d8c1b2890_0 .net "instr_set_in", 3 0, v0x557d8c1afc40_0;  alias, 1 drivers
+v0x557d8c1b2930_0 .net "instr_set_out", 3 0, v0x557d8c1b1c60_0;  alias, 1 drivers
+v0x557d8c1b2a40_0 .net "pc_in", 11 0, v0x557d8c1afe50_0;  alias, 1 drivers
+v0x557d8c1b2ae0_0 .net "pc_out", 11 0, v0x557d8c1b1e70_0;  alias, 1 drivers
+v0x557d8c1b2bd0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+v0x557d8c1b2c70_0 .net "stage_pc", 11 0, L_0x557d8c1b7390;  1 drivers
+S_0x557d8c1b15a0 .scope module, "u_latch5raro" "latch5raro" 30 23, 31 4 0, S_0x557d8c1b12f0;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /INPUT 12 "instr_in";
+    .port_info 3 /INPUT 4 "instr_set_in";
+    .port_info 4 /INPUT 12 "pc_in";
     .port_info 5 /OUTPUT 12 "instr_out";
-L_0x58db71206140 .functor BUFZ 12, v0x58db71201760_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db71203000_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db712030c0_0 .net "instr_in", 11 0, v0x58db71201760_0;  alias, 1 drivers
-v0x58db712031d0_0 .net "instr_out", 11 0, L_0x58db71206140;  alias, 1 drivers
-v0x58db71203290_0 .net "pc_in", 11 0, v0x58db71201900_0;  alias, 1 drivers
-v0x58db71203350_0 .net "pc_out", 11 0, L_0x58db71206090;  alias, 1 drivers
-v0x58db71203460_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db71202a20 .scope module, "u_stage5ro" "stage5ro" 33 11, 34 4 0, S_0x58db712027a0;
+    .port_info 6 /OUTPUT 4 "instr_set_out";
+    .port_info 7 /OUTPUT 12 "pc_out";
+v0x557d8c1b18c0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b1980_0 .net "instr_in", 11 0, v0x557d8c1afa70_0;  alias, 1 drivers
+v0x557d8c1b1a90_0 .var "instr_out", 11 0;
+v0x557d8c1b1b50_0 .net "instr_set_in", 3 0, v0x557d8c1afc40_0;  alias, 1 drivers
+v0x557d8c1b1c60_0 .var "instr_set_out", 3 0;
+v0x557d8c1b1d90_0 .net "pc_in", 11 0, L_0x557d8c1b7390;  alias, 1 drivers
+v0x557d8c1b1e70_0 .var "pc_out", 11 0;
+v0x557d8c1b1f50_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1b2140 .scope module, "u_stage5ra" "stage5ra" 30 15, 32 4 0, S_0x557d8c1b12f0;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 1 "rst";
     .port_info 2 /INPUT 12 "pc_in";
     .port_info 3 /OUTPUT 12 "pc_out";
-L_0x58db71206090 .functor BUFZ 12, v0x58db71201900_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
-v0x58db71202c20_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db71202ce0_0 .net "pc_in", 11 0, v0x58db71201900_0;  alias, 1 drivers
-v0x58db71202df0_0 .net "pc_out", 11 0, L_0x58db71206090;  alias, 1 drivers
-v0x58db71202eb0_0 .net "rst", 0 0, v0x58db71205520_0;  alias, 1 drivers
-S_0x58db712035e0 .scope module, "u_meminstr" "meminstr" 11 57, 35 3 0, S_0x58db711f7ae0;
+L_0x557d8c1b7390 .functor BUFZ 12, v0x557d8c1afe50_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1b22f0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b2390_0 .net "pc_in", 11 0, v0x557d8c1afe50_0;  alias, 1 drivers
+v0x557d8c1b24a0_0 .net "pc_out", 11 0, L_0x557d8c1b7390;  alias, 1 drivers
+v0x557d8c1b2540_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1b2ef0 .scope module, "u_control5ro" "control5ro" 11 137, 33 2 0, S_0x557d8c1a6370;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /INPUT 12 "pc_in";
+    .port_info 3 /INPUT 12 "instr_in";
+    .port_info 4 /INPUT 4 "instr_set_in";
+    .port_info 5 /OUTPUT 12 "pc_out";
+    .port_info 6 /OUTPUT 12 "instr_out";
+    .port_info 7 /OUTPUT 4 "instr_set_out";
+L_0x557d8c1b74d0 .functor BUFZ 12, v0x557d8c1b1a90_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+L_0x557d8c1b7660 .functor BUFZ 4, v0x557d8c1b1c60_0, C4<0000>, C4<0000>, C4<0000>;
+v0x557d8c1b3780_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b3840_0 .net "instr_in", 11 0, v0x557d8c1b1a90_0;  alias, 1 drivers
+v0x557d8c1b3950_0 .net "instr_out", 11 0, L_0x557d8c1b74d0;  alias, 1 drivers
+v0x557d8c1b3a10_0 .net "instr_set_in", 3 0, v0x557d8c1b1c60_0;  alias, 1 drivers
+v0x557d8c1b3b20_0 .net "instr_set_out", 3 0, L_0x557d8c1b7660;  alias, 1 drivers
+v0x557d8c1b3c50_0 .net "pc_in", 11 0, v0x557d8c1b1e70_0;  alias, 1 drivers
+v0x557d8c1b3d10_0 .net "pc_out", 11 0, L_0x557d8c1b7420;  alias, 1 drivers
+v0x557d8c1b3dd0_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1b31a0 .scope module, "u_stage5ro" "stage5ro" 33 13, 34 4 0, S_0x557d8c1b2ef0;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /INPUT 12 "pc_in";
+    .port_info 3 /OUTPUT 12 "pc_out";
+L_0x557d8c1b7420 .functor BUFZ 12, v0x557d8c1b1e70_0, C4<000000000000>, C4<000000000000>, C4<000000000000>;
+v0x557d8c1b33a0_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b3460_0 .net "pc_in", 11 0, v0x557d8c1b1e70_0;  alias, 1 drivers
+v0x557d8c1b3570_0 .net "pc_out", 11 0, L_0x557d8c1b7420;  alias, 1 drivers
+v0x557d8c1b3630_0 .net "rst", 0 0, v0x557d8c1b6630_0;  alias, 1 drivers
+S_0x557d8c1b3fa0 .scope module, "u_meminstr" "meminstr" 11 67, 35 3 0, S_0x557d8c1a6370;
  .timescale 0 0;
     .port_info 0 /INPUT 1 "clk";
     .port_info 1 /INPUT 12 "addr";
     .port_info 2 /OUTPUT 12 "data";
-v0x58db71203b20_0 .net "addr", 11 0, L_0x58db71205aa0;  alias, 1 drivers
-v0x58db71203c50_0 .net "clk", 0 0, v0x58db71205480_0;  alias, 1 drivers
-v0x58db71203d10_0 .var "data", 11 0;
-v0x58db71203e00 .array "mem", 4095 0, 11 0;
-E_0x58db711f94b0 .event posedge, v0x58db711f8180_0;
-S_0x58db71203820 .scope begin, "$unm_blk_24" "$unm_blk_24" 35 11, 35 11 0, S_0x58db712035e0;
+v0x557d8c1b4520_0 .net "addr", 11 0, L_0x557d8c1b6b10;  alias, 1 drivers
+v0x557d8c1b4650_0 .net "clk", 0 0, v0x557d8c1b6590_0;  alias, 1 drivers
+v0x557d8c1b4710_0 .var "data", 11 0;
+v0x557d8c1b4800 .array "mem", 4095 0, 11 0;
+E_0x557d8c1a7ca0 .event posedge, v0x557d8c1a6970_0;
+S_0x557d8c1b4220 .scope begin, "$unm_blk_24" "$unm_blk_24" 35 11, 35 11 0, S_0x557d8c1b3fa0;
  .timescale 0 0;
-v0x58db71203a20_0 .var/i "i", 31 0;
-    .scope S_0x58db71180a90;
+v0x557d8c1b4420_0 .var/i "i", 31 0;
+    .scope S_0x557d8c1160b0;
 T_0 ;
-    %wait E_0x58db71140b20;
-    %load/vec4 v0x58db711f5f60_0;
+    %wait E_0x557d8c0dbb20;
+    %load/vec4 v0x557d8c1a4890_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_0.0, 8;
-    %load/vec4 v0x58db711db600_0;
-    %load/vec4 v0x58db711de840_0;
+    %load/vec4 v0x557d8c1878d0_0;
+    %load/vec4 v0x557d8c18cc70_0;
     %pad/u 14;
     %ix/vec4 3;
     %ix/load 4, 0, 0; Constant delay
-    %assign/vec4/a/d v0x58db711dd880, 0, 4;
+    %assign/vec4/a/d v0x557d8c18ba40, 0, 4;
 T_0.0 ;
-    %load/vec4 v0x58db711de840_0;
+    %load/vec4 v0x557d8c18cc70_0;
     %pad/u 14;
     %ix/vec4 4;
-    %load/vec4a v0x58db711dd880, 4;
-    %assign/vec4 v0x58db711db530_0, 0;
+    %load/vec4a v0x557d8c18ba40, 4;
+    %assign/vec4 v0x557d8c187800_0, 0;
     %jmp T_0;
     .thread T_0;
-    .scope S_0x58db71180c20;
+    .scope S_0x557d8c118fb0;
 T_1 ;
-    %wait E_0x58db7117a240;
-    %load/vec4 v0x58db711f6380_0;
+    %wait E_0x557d8c115240;
+    %load/vec4 v0x557d8c1a4cb0_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_1.0, 8;
     %pushi/vec4 0, 0, 4;
-    %assign/vec4 v0x58db711f62c0_0, 0;
+    %assign/vec4 v0x557d8c1a4bf0_0, 0;
     %jmp T_1.1;
 T_1.0 ;
-    %load/vec4 v0x58db711f6440_0;
+    %load/vec4 v0x557d8c1a4d70_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_1.2, 8;
-    %load/vec4 v0x58db711f61e0_0;
-    %assign/vec4 v0x58db711f62c0_0, 0;
+    %load/vec4 v0x557d8c1a4b10_0;
+    %assign/vec4 v0x557d8c1a4bf0_0, 0;
 T_1.2 ;
 T_1.1 ;
     %jmp T_1;
     .thread T_1;
-    .scope S_0x58db711835c0;
+    .scope S_0x557d8c119140;
 T_2 ;
-    %wait E_0x58db711648c0;
-    %load/vec4 v0x58db711f71a0_0;
+    %wait E_0x557d8c0ff8c0;
+    %load/vec4 v0x557d8c1a5a30_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_2.0, 8;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0x58db711f6c80_0, 0, 32;
+    %store/vec4 v0x557d8c1a5510_0, 0, 32;
 T_2.2 ;
-    %load/vec4 v0x58db711f6c80_0;
+    %load/vec4 v0x557d8c1a5510_0;
     %cmpi/s 16, 0, 32;
     %jmp/0xz T_2.3, 5;
     %pushi/vec4 0, 0, 12;
-    %ix/getv/s 3, v0x58db711f6c80_0;
+    %ix/getv/s 3, v0x557d8c1a5510_0;
     %ix/load 4, 0, 0; Constant delay
-    %assign/vec4/a/d v0x58db711f70e0, 0, 4;
-    %load/vec4 v0x58db711f6c80_0;
+    %assign/vec4/a/d v0x557d8c1a5970, 0, 4;
+    %load/vec4 v0x557d8c1a5510_0;
     %addi 1, 0, 32;
-    %store/vec4 v0x58db711f6c80_0, 0, 32;
+    %store/vec4 v0x557d8c1a5510_0, 0, 32;
     %jmp T_2.2;
 T_2.3 ;
     %jmp T_2.1;
 T_2.0 ;
-    %load/vec4 v0x58db711f7420_0;
+    %load/vec4 v0x557d8c1a5cb0_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_2.4, 8;
-    %load/vec4 v0x58db711f7340_0;
-    %load/vec4 v0x58db711f7260_0;
+    %load/vec4 v0x557d8c1a5bd0_0;
+    %load/vec4 v0x557d8c1a5af0_0;
     %pad/u 6;
     %ix/vec4 3;
     %ix/load 4, 0, 0; Constant delay
-    %assign/vec4/a/d v0x58db711f70e0, 0, 4;
+    %assign/vec4/a/d v0x557d8c1a5970, 0, 4;
 T_2.4 ;
 T_2.1 ;
     %jmp T_2;
     .thread T_2;
-    .scope S_0x58db71183830;
+    .scope S_0x557d8c11ca70;
 T_3 ;
-    %wait E_0x58db711e4150;
-    %load/vec4 v0x58db711f78c0_0;
+    %wait E_0x557d8c193640;
+    %load/vec4 v0x557d8c1a6150_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_3.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711f7800_0, 0;
+    %assign/vec4 v0x557d8c1a6090_0, 0;
     %jmp T_3.1;
 T_3.0 ;
-    %load/vec4 v0x58db711f7980_0;
+    %load/vec4 v0x557d8c1a6210_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_3.2, 8;
-    %load/vec4 v0x58db711f7720_0;
-    %assign/vec4 v0x58db711f7800_0, 0;
+    %load/vec4 v0x557d8c1a5fb0_0;
+    %assign/vec4 v0x557d8c1a6090_0, 0;
 T_3.2 ;
 T_3.1 ;
     %jmp T_3;
     .thread T_3;
-    .scope S_0x58db711f7f00;
+    .scope S_0x557d8c1a66f0;
 T_4 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db711f8430_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1a6c20_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_4.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711f8340_0, 0;
+    %assign/vec4 v0x557d8c1a6b30_0, 0;
     %jmp T_4.1;
 T_4.0 ;
-    %load/vec4 v0x58db711f8260_0;
-    %assign/vec4 v0x58db711f8340_0, 0;
+    %load/vec4 v0x557d8c1a6a50_0;
+    %assign/vec4 v0x557d8c1a6b30_0, 0;
 T_4.1 ;
     %jmp T_4;
     .thread T_4;
-    .scope S_0x58db711f9590;
+    .scope S_0x557d8c1a7d80;
 T_5 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db711f9cc0_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1a84b0_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_5.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711f99f0_0, 0;
+    %assign/vec4 v0x557d8c1a81e0_0, 0;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711f9b90_0, 0;
+    %assign/vec4 v0x557d8c1a8380_0, 0;
     %jmp T_5.1;
 T_5.0 ;
-    %load/vec4 v0x58db711f9910_0;
-    %assign/vec4 v0x58db711f99f0_0, 0;
-    %load/vec4 v0x58db711f9ab0_0;
-    %assign/vec4 v0x58db711f9b90_0, 0;
+    %load/vec4 v0x557d8c1a8100_0;
+    %assign/vec4 v0x557d8c1a81e0_0, 0;
+    %load/vec4 v0x557d8c1a82a0_0;
+    %assign/vec4 v0x557d8c1a8380_0, 0;
 T_5.1 ;
     %jmp T_5;
     .thread T_5;
-    .scope S_0x58db712035e0;
+    .scope S_0x557d8c1b3fa0;
 T_6 ;
-    %fork t_1, S_0x58db71203820;
+    %fork t_1, S_0x557d8c1b4220;
     %jmp t_0;
-    .scope S_0x58db71203820;
+    .scope S_0x557d8c1b4220;
 t_1 ;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0x58db71203a20_0, 0, 32;
+    %store/vec4 v0x557d8c1b4420_0, 0, 32;
 T_6.0 ;
-    %load/vec4 v0x58db71203a20_0;
+    %load/vec4 v0x557d8c1b4420_0;
     %cmpi/s 4096, 0, 32;
     %jmp/0xz T_6.1, 5;
     %pushi/vec4 0, 0, 12;
-    %ix/getv/s 4, v0x58db71203a20_0;
-    %store/vec4a v0x58db71203e00, 4, 0;
-    %load/vec4 v0x58db71203a20_0;
+    %ix/getv/s 4, v0x557d8c1b4420_0;
+    %store/vec4a v0x557d8c1b4800, 4, 0;
+    %load/vec4 v0x557d8c1b4420_0;
     %addi 1, 0, 32;
-    %store/vec4 v0x58db71203a20_0, 0, 32;
+    %store/vec4 v0x557d8c1b4420_0, 0, 32;
     %jmp T_6.0;
 T_6.1 ;
-    %vpi_call/w 35 17 "$readmemh", "instr_mem_init.hex", v0x58db71203e00 {0 0 0};
+    %vpi_call/w 35 17 "$readmemh", "instr_mem_init.hex", v0x557d8c1b4800 {0 0 0};
     %end;
-    .scope S_0x58db712035e0;
+    .scope S_0x557d8c1b3fa0;
 t_0 %join;
     %end;
     .thread T_6;
-    .scope S_0x58db712035e0;
+    .scope S_0x557d8c1b3fa0;
 T_7 ;
-    %wait E_0x58db711f94b0;
-    %load/vec4 v0x58db71203b20_0;
+    %wait E_0x557d8c1a7ca0;
+    %load/vec4 v0x557d8c1b4520_0;
     %pad/u 14;
     %ix/vec4 4;
-    %load/vec4a v0x58db71203e00, 4;
-    %assign/vec4 v0x58db71203d10_0, 0;
+    %load/vec4a v0x557d8c1b4800, 4;
+    %assign/vec4 v0x557d8c1b4710_0, 0;
     %jmp T_7;
     .thread T_7;
-    .scope S_0x58db711fafc0;
+    .scope S_0x557d8c1a9830;
 T_8 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db711fb720_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1aa190_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_8.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711fb450_0, 0;
+    %assign/vec4 v0x557d8c1a9d00_0, 0;
+    %pushi/vec4 0, 0, 4;
+    %assign/vec4 v0x557d8c1a9ea0_0, 0;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711fb5f0_0, 0;
+    %assign/vec4 v0x557d8c1aa0b0_0, 0;
     %jmp T_8.1;
 T_8.0 ;
-    %load/vec4 v0x58db711fb340_0;
-    %assign/vec4 v0x58db711fb450_0, 0;
-    %load/vec4 v0x58db711fb510_0;
-    %assign/vec4 v0x58db711fb5f0_0, 0;
+    %load/vec4 v0x557d8c1a9bf0_0;
+    %assign/vec4 v0x557d8c1a9d00_0, 0;
+    %load/vec4 v0x557d8c1a9dc0_0;
+    %assign/vec4 v0x557d8c1a9ea0_0, 0;
+    %load/vec4 v0x557d8c1a9fd0_0;
+    %assign/vec4 v0x557d8c1aa0b0_0, 0;
 T_8.1 ;
     %jmp T_8;
     .thread T_8;
-    .scope S_0x58db711fc820;
+    .scope S_0x557d8c1abd90;
 T_9 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db711fcfa0_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1ac740_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_9.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711fccd0_0, 0;
+    %assign/vec4 v0x557d8c1ac280_0, 0;
+    %pushi/vec4 0, 0, 4;
+    %assign/vec4 v0x557d8c1ac450_0, 0;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711fce70_0, 0;
+    %assign/vec4 v0x557d8c1ac660_0, 0;
     %jmp T_9.1;
 T_9.0 ;
-    %load/vec4 v0x58db711fcbc0_0;
-    %assign/vec4 v0x58db711fccd0_0, 0;
-    %load/vec4 v0x58db711fcd90_0;
-    %assign/vec4 v0x58db711fce70_0, 0;
+    %load/vec4 v0x557d8c1ac170_0;
+    %assign/vec4 v0x557d8c1ac280_0, 0;
+    %load/vec4 v0x557d8c1ac340_0;
+    %assign/vec4 v0x557d8c1ac450_0, 0;
+    %load/vec4 v0x557d8c1ac580_0;
+    %assign/vec4 v0x557d8c1ac660_0, 0;
 T_9.1 ;
     %jmp T_9;
     .thread T_9;
-    .scope S_0x58db711fdfe0;
+    .scope S_0x557d8c1ad9b0;
 T_10 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db711fe760_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1ae360_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_10.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711fe490_0, 0;
+    %assign/vec4 v0x557d8c1adea0_0, 0;
+    %pushi/vec4 0, 0, 4;
+    %assign/vec4 v0x557d8c1ae070_0, 0;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711fe630_0, 0;
+    %assign/vec4 v0x557d8c1ae280_0, 0;
     %jmp T_10.1;
 T_10.0 ;
-    %load/vec4 v0x58db711fe380_0;
-    %assign/vec4 v0x58db711fe490_0, 0;
-    %load/vec4 v0x58db711fe550_0;
-    %assign/vec4 v0x58db711fe630_0, 0;
+    %load/vec4 v0x557d8c1add90_0;
+    %assign/vec4 v0x557d8c1adea0_0, 0;
+    %load/vec4 v0x557d8c1adf60_0;
+    %assign/vec4 v0x557d8c1ae070_0, 0;
+    %load/vec4 v0x557d8c1ae1a0_0;
+    %assign/vec4 v0x557d8c1ae280_0, 0;
 T_10.1 ;
     %jmp T_10;
     .thread T_10;
-    .scope S_0x58db711ff720;
+    .scope S_0x557d8c1af580;
 T_11 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db711ffea0_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1aff30_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_11.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711ffbd0_0, 0;
+    %assign/vec4 v0x557d8c1afa70_0, 0;
+    %pushi/vec4 0, 0, 4;
+    %assign/vec4 v0x557d8c1afc40_0, 0;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db711ffd70_0, 0;
+    %assign/vec4 v0x557d8c1afe50_0, 0;
     %jmp T_11.1;
 T_11.0 ;
-    %load/vec4 v0x58db711ffac0_0;
-    %assign/vec4 v0x58db711ffbd0_0, 0;
-    %load/vec4 v0x58db711ffc90_0;
-    %assign/vec4 v0x58db711ffd70_0, 0;
+    %load/vec4 v0x557d8c1af960_0;
+    %assign/vec4 v0x557d8c1afa70_0, 0;
+    %load/vec4 v0x557d8c1afb30_0;
+    %assign/vec4 v0x557d8c1afc40_0, 0;
+    %load/vec4 v0x557d8c1afd70_0;
+    %assign/vec4 v0x557d8c1afe50_0, 0;
 T_11.1 ;
     %jmp T_11;
     .thread T_11;
-    .scope S_0x58db712012b0;
+    .scope S_0x557d8c1b15a0;
 T_12 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db71201a30_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1b1f50_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_12.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db71201760_0, 0;
+    %assign/vec4 v0x557d8c1b1a90_0, 0;
+    %pushi/vec4 0, 0, 4;
+    %assign/vec4 v0x557d8c1b1c60_0, 0;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db71201900_0, 0;
+    %assign/vec4 v0x557d8c1b1e70_0, 0;
     %jmp T_12.1;
 T_12.0 ;
-    %load/vec4 v0x58db71201650_0;
-    %assign/vec4 v0x58db71201760_0, 0;
-    %load/vec4 v0x58db71201820_0;
-    %assign/vec4 v0x58db71201900_0, 0;
+    %load/vec4 v0x557d8c1b1980_0;
+    %assign/vec4 v0x557d8c1b1a90_0, 0;
+    %load/vec4 v0x557d8c1b1b50_0;
+    %assign/vec4 v0x557d8c1b1c60_0, 0;
+    %load/vec4 v0x557d8c1b1d90_0;
+    %assign/vec4 v0x557d8c1b1e70_0, 0;
 T_12.1 ;
     %jmp T_12;
     .thread T_12;
-    .scope S_0x58db711f7ae0;
+    .scope S_0x557d8c1a6370;
 T_13 ;
-    %wait E_0x58db711f8100;
-    %load/vec4 v0x58db71205380_0;
+    %wait E_0x557d8c1a68f0;
+    %load/vec4 v0x557d8c1b6490_0;
     %flag_set/vec4 8;
     %jmp/0xz  T_13.0, 8;
     %pushi/vec4 0, 0, 12;
-    %assign/vec4 v0x58db71204310_0, 0;
+    %assign/vec4 v0x557d8c1b4fb0_0, 0;
     %jmp T_13.1;
 T_13.0 ;
-    %load/vec4 v0x58db71204310_0;
+    %load/vec4 v0x557d8c1b4fb0_0;
     %addi 1, 0, 12;
-    %assign/vec4 v0x58db71204310_0, 0;
+    %assign/vec4 v0x557d8c1b4fb0_0, 0;
 T_13.1 ;
     %jmp T_13;
     .thread T_13;
-    .scope S_0x58db711860f0;
+    .scope S_0x557d8c11cc00;
 T_14 ;
     %pushi/vec4 0, 0, 32;
-    %store/vec4 v0x58db712055e0_0, 0, 32;
+    %store/vec4 v0x557d8c1b66f0_0, 0, 32;
     %end;
     .thread T_14, $init;
-    .scope S_0x58db711860f0;
+    .scope S_0x557d8c11cc00;
 T_15 ;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0x58db71205480_0, 0, 1;
+    %store/vec4 v0x557d8c1b6590_0, 0, 1;
     %end;
     .thread T_15;
-    .scope S_0x58db711860f0;
+    .scope S_0x557d8c11cc00;
 T_16 ;
     %delay 62500, 0;
-    %load/vec4 v0x58db71205480_0;
+    %load/vec4 v0x557d8c1b6590_0;
     %inv;
-    %store/vec4 v0x58db71205480_0, 0, 1;
+    %store/vec4 v0x557d8c1b6590_0, 0, 1;
     %jmp T_16;
     .thread T_16;
-    .scope S_0x58db711860f0;
+    .scope S_0x557d8c11cc00;
 T_17 ;
     %pushi/vec4 1, 0, 1;
-    %store/vec4 v0x58db71205520_0, 0, 1;
+    %store/vec4 v0x557d8c1b6630_0, 0, 1;
     %delay 250000, 0;
     %pushi/vec4 0, 0, 1;
-    %store/vec4 v0x58db71205520_0, 0, 1;
+    %store/vec4 v0x557d8c1b6630_0, 0, 1;
     %pushi/vec4 20, 0, 32;
 T_17.0 %dup/vec4;
     %pushi/vec4 0, 0, 32;
@@ -780,21 +871,22 @@ T_17.0 %dup/vec4;
     %jmp/1 T_17.1, 4;
     %pushi/vec4 1, 0, 32;
     %sub;
-    %wait E_0x58db711f94b0;
+    %wait E_0x557d8c1a7ca0;
     %jmp T_17.0;
 T_17.1 ;
     %pop/vec4 1;
     %vpi_call/w 10 32 "$finish" {0 0 0};
     %end;
     .thread T_17;
-    .scope S_0x58db711860f0;
+    .scope S_0x557d8c11cc00;
 T_18 ;
-    %wait E_0x58db711f94b0;
-    %vpi_call/w 10 38 "$display", "tick %0d : rst=%b IA=%h IAIF=%h IFID=%h IDEX=%h EXMA=%h MAMO=%h MORA=%h RARO=%h FINAL=%h", v0x58db712055e0_0, v0x58db71205520_0, v0x58db71204310_0, v0x58db71204420_0, v0x58db712049f0_0, v0x58db712046c0_0, v0x58db71204080_0, v0x58db71204e10_0, v0x58db712050b0_0, v0x58db71205230_0, v0x58db71204270_0 {0 0 0};
-    %vpi_call/w 10 49 "$display", "tick %0d : IFID_instr=%h IDEX_instr=%h EXMA_instr=%h MAMO_instr=%h MORA_instr=%h RARO_instr=%h FINAL_instr=%h", v0x58db712055e0_0, v0x58db712048a0_0, v0x58db71204570_0, v0x58db71203fc0_0, v0x58db71204cc0_0, v0x58db71204f60_0, v0x58db71205170_0, v0x58db712041b0_0 {0 0 0};
-    %load/vec4 v0x58db712055e0_0;
+    %wait E_0x557d8c1a7ca0;
+    %vpi_call/w 10 38 "$display", "tick %0d : rst=%b IA=%h IAIF=%h IFID=%h IDEX=%h EXMA=%h MAMO=%h MORA=%h RARO=%h FINAL=%h", v0x557d8c1b66f0_0, v0x557d8c1b6630_0, v0x557d8c1b4fb0_0, v0x557d8c1b5050_0, v0x557d8c1b56e0_0, v0x557d8c1b5380_0, v0x557d8c1b4b10_0, v0x557d8c1b5b30_0, v0x557d8c1b5f20_0, v0x557d8c1b6280_0, v0x557d8c1b4e50_0 {0 0 0};
+    %vpi_call/w 10 49 "$display", "tick %0d : IFID_instr=%h IDEX_instr=%h EXMA_instr=%h MAMO_instr=%h MORA_instr=%h RARO_instr=%h FINAL_instr=%h", v0x557d8c1b66f0_0, v0x557d8c1b5620_0, v0x557d8c1b5230_0, v0x557d8c1b49c0_0, v0x557d8c1b5a70_0, v0x557d8c1b5dd0_0, v0x557d8c1b61c0_0, v0x557d8c1b4d90_0 {0 0 0};
+    %vpi_call/w 10 58 "$display", "tick %0d : IFID_set=%h IDEX_set=%h EXMA_set=%h MAMO_set=%h MORA_set=%h RARO_set=%h FINAL_set=%h", v0x557d8c1b66f0_0, v0x557d8c1b5830_0, v0x557d8c1b54d0_0, v0x557d8c1b4c40_0, v0x557d8c1b5c80_0, v0x557d8c1b6070_0, v0x557d8c1b63d0_0, v0x557d8c1b4ef0_0 {0 0 0};
+    %load/vec4 v0x557d8c1b66f0_0;
     %addi 1, 0, 32;
-    %store/vec4 v0x58db712055e0_0, 0, 32;
+    %store/vec4 v0x557d8c1b66f0_0, 0, 32;
     %jmp T_18;
     .thread T_18;
 # The file index is used to find the file name in the following table.


### PR DESCRIPTION
## Summary
- track the current instruction set in the pipeline
- propagate `instr_set` through all latches and control blocks
- expose the set wires in `henad` for testbench use
- show the set value each cycle in the testbench

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_68506586bda8832fab53627ed42bab56