### PR TITLE
Fix SW instruction decode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test.vvp
+build.log

--- a/src/control2id.v
+++ b/src/control2id.v
@@ -17,8 +17,10 @@ module control2id(
 
     // Stage 2 Instruction Decode
     wire [3:0] stage_set;
-    // NOP or SW instructions are fully handled in the decode stage, so the
-    // following instruction value will be forwarded instead of the original.
+    // NOP or SW instructions are fully handled in the decode stage.  When
+    // SW is seen the instruction set is updated, so the original instruction
+    // should not proceed further down the pipeline.  In these cases a NOP is
+    // forwarded instead of the actual instruction.
     wire [11:0] forwarded_instr;
 
     stage2id u_stage2id(

--- a/src/stage2id.v
+++ b/src/stage2id.v
@@ -16,15 +16,17 @@ module stage2id(
     output wire [3:0]  instr_set_out,
     output wire        enable_out
 );
-    // No real decode logic yet.  The instruction set would normally
-    // change when a special "SW" instruction is decoded.  For now the
-    // stage simply passes the current set through, incrementing it when
-    // the opcode matches OPC_SW.  This remains purely combinational.
+    // No real decode logic yet.  The instruction set changes when the
+    // special "SW" instruction is decoded.  The instruction encodes the
+    // new set in its lowest three bits, which map to the constants in
+    // `iset.vh`.  The update is purely combinational for now.
 
     wire [3:0] opcode = instr_in[11:8];
 
     assign pc_out = pc_in;
-    assign instr_set_out = (opcode == `OPC_SW) ? instr_set_in + 4'd1
+    // When OPC_SW is seen, switch to the set encoded in bits [2:0] of the
+    // instruction.  Otherwise propagate the current set unchanged.
+    assign instr_set_out = (opcode == `OPC_SW) ? {1'b0, instr_in[2:0]}
                                                : instr_set_in;
     // Propagate enable
     assign enable_out = enable;


### PR DESCRIPTION
## Summary
- keep build artifacts out of git
- update SW instruction handling in `stage2id`
- clarify comment in `control2id`

## Testing
- `iverilog -g2012 -o test.vvp src/*.v` *(fails: macro ISET_BASE undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68555ea74a04832fbc132875a09d050a