### PR TITLE
Add ALU and integrate into pipeline

### DIFF
--- a/src/alu.v
+++ b/src/alu.v
@@ -1,0 +1,77 @@
+// alu.v
+// Simple ALU for Henad core implementing a subset of operations
+`include "src/opcodes.vh"
+`include "src/flags.vh"
+module alu(
+    input  wire [3:0] opcode,
+    input  wire [11:0] src,
+    input  wire [11:0] tgt,
+    input  wire [11:0] imm,
+    input  wire        imm_en,
+    input  wire        sgn_en,
+    output reg  [11:0] result,
+    output reg  [3:0]  flags
+);
+    // internal wires for arithmetic operations
+    reg [12:0] calc;
+    reg        carry;
+    reg        overflow;
+    reg [11:0] operand;
+    reg [11:0] tgt_op;
+    reg [11:0] src_val;
+    
+    always @* begin
+        operand = imm_en ? imm : src;
+        tgt_op  = tgt;
+        result  = 12'b0;
+        carry   = 1'b0;
+        overflow = 1'b0;
+        src_val = operand;
+        case (opcode)
+            `OPC_R_MOV, `OPC_I_MOVi, `OPC_IS_MOVis: begin
+                result = operand;
+            end
+            `OPC_R_ADD, `OPC_I_ADDi, `OPC_RS_ADDs, `OPC_IS_ADDis: begin
+                calc = tgt_op + operand;
+                result = calc[11:0];
+                carry = calc[12];
+                overflow = (~(tgt_op[11] ^ operand[11]) & (result[11] ^ tgt_op[11]));
+            end
+            `OPC_R_SUB, `OPC_I_SUBi, `OPC_RS_SUBs, `OPC_IS_SUBis,
+            `OPC_R_CMP, `OPC_I_CMPi, `OPC_RS_CMPs, `OPC_IS_CMPis: begin
+                calc = tgt_op + (~operand + 12'd1);
+                result = calc[11:0];
+                carry = calc[12];
+                overflow = ((tgt_op[11] ^ operand[11]) & (result[11] ^ tgt_op[11]));
+            end
+            `OPC_R_NOT: begin
+                result = ~tgt_op;
+            end
+            `OPC_R_AND, `OPC_I_ANDi: begin
+                result = tgt_op & operand;
+            end
+            `OPC_R_OR, `OPC_I_ORi: begin
+                result = tgt_op | operand;
+            end
+            `OPC_R_XOR, `OPC_I_XORi: begin
+                result = tgt_op ^ operand;
+            end
+            `OPC_R_SL, `OPC_I_SLi: begin
+                result = tgt_op << operand[3:0];
+            end
+            `OPC_R_SR, `OPC_I_SRi, `OPC_RS_SRs, `OPC_IS_SRis: begin
+                if (sgn_en)
+                    result = $signed(tgt_op) >>> operand[3:0];
+                else
+                    result = tgt_op >> operand[3:0];
+            end
+            default: begin
+                result = 12'b0;
+            end
+        endcase
+        flags[`FLAG_Z] = (result == 12'b0);
+        flags[`FLAG_C] = carry;
+        flags[`FLAG_N] = result[11];
+        flags[`FLAG_V] = overflow;
+    end
+endmodule

--- a/src/henad.v
+++ b/src/henad.v
@@ -77,6 +77,19 @@ module henad(
     wire [5:0] ex_imm_val;
     wire [5:0] ex_off;
     wire       ex_sgn_en;
+    wire [11:0] ex_result;
+    wire [3:0]  ex_flags;
+    wire [11:0] ma_result;
+    wire [3:0]  ma_flags;
+    wire [11:0] mo_result;
+    wire [3:0]  mo_flags;
+    wire [11:0] ra_result;
+    wire [3:0]  ra_flags;
+    wire [11:0] ro_result;
+    wire [3:0]  ro_flags;
+    wire [3:0]  reg_waddr;
+    wire        reg_we;
+    wire        flag_we;
 
     // Update ia_pc and enable signals
     always @(posedge clk or posedge rst) begin
@@ -135,6 +148,29 @@ module henad(
         .data(instr_mem_data)
     );
 
+    // General purpose register file and flag register
+    wire [11:0] reg_src_data;
+    wire [11:0] reg_tgt_data;
+    reggp u_reggp(
+        .clk(clk),
+        .rst(rst),
+        .raddr1(id_src_gp),
+        .raddr2(id_tgt_gp),
+        .waddr(reg_waddr),
+        .wdata(ro_result),
+        .we(reg_we),
+        .rdata1(reg_src_data),
+        .rdata2(reg_tgt_data)
+    );
+
+    regflag u_regflag(
+        .clk(clk),
+        .rst(rst),
+        .flag_in(ro_flags),
+        .we(flag_we),
+        .flag_out()
+    );
+
     // Initial instruction set for the pipeline
     assign ifid_set = `ISET_R;
 
@@ -181,6 +217,8 @@ module henad(
         .imm_val_in(id_imm_val),
         .off_in(id_off),
         .sgn_en_in(id_sgn_en),
+        .src_data_in(reg_src_data),
+        .tgt_data_in(reg_tgt_data),
         .pc_out(exma_pc),
         .instr_out(exma_instr),
         .instr_set_out(exma_set),
@@ -193,7 +231,9 @@ module henad(
         .imm_hilo_out(ex_imm_hilo),
         .imm_val_out(ex_imm_val),
         .off_out(ex_off),
-        .sgn_en_out(ex_sgn_en)
+        .sgn_en_out(ex_sgn_en),
+        .result_out(ex_result),
+        .flags_out(ex_flags)
     );
 
     // Memory address stage
@@ -205,9 +245,13 @@ module henad(
         .pc_in(exma_pc),
         .instr_in(exma_instr),
         .instr_set_in(exma_set),
+        .result_in(ex_result),
+        .flags_in(ex_flags),
         .pc_out(mamo_pc),
         .instr_out(mamo_instr),
-        .instr_set_out(mamo_set)
+        .instr_set_out(mamo_set),
+        .result_out(ma_result),
+        .flags_out(ma_flags)
     );
 
     // Memory operation stage
@@ -219,9 +263,13 @@ module henad(
         .pc_in(mamo_pc),
         .instr_in(mamo_instr),
         .instr_set_in(mamo_set),
+        .result_in(ma_result),
+        .flags_in(ma_flags),
         .pc_out(mora_pc),
         .instr_out(mora_instr),
-        .instr_set_out(mora_set)
+        .instr_set_out(mora_set),
+        .result_out(mo_result),
+        .flags_out(mo_flags)
     );
 
     // Register address stage
@@ -233,9 +281,13 @@ module henad(
         .pc_in(mora_pc),
         .instr_in(mora_instr),
         .instr_set_in(mora_set),
+        .result_in(mo_result),
+        .flags_in(mo_flags),
         .pc_out(raro_pc),
         .instr_out(raro_instr),
-        .instr_set_out(raro_set)
+        .instr_set_out(raro_set),
+        .result_out(ra_result),
+        .flags_out(ra_flags)
     );
 
     // Register operation stage
@@ -246,8 +298,15 @@ module henad(
         .pc_in(raro_pc),
         .instr_in(raro_instr),
         .instr_set_in(raro_set),
+        .result_in(ra_result),
+        .flags_in(ra_flags),
         .pc_out(final_pc),
         .instr_out(final_instr),
-        .instr_set_out(final_set)
+        .instr_set_out(final_set),
+        .reg_waddr(reg_waddr),
+        .reg_wdata(ro_result),
+        .reg_we(reg_we),
+        .flag_wdata(ro_flags),
+        .flag_we(flag_we)
     );
 endmodule

--- a/src/stage3ex.v
+++ b/src/stage3ex.v
@@ -1,5 +1,7 @@
 // stage3ex.v
 `include "src/iset.vh"
+`include "src/opcodes.vh"
+`include "src/flags.vh"
 module stage3ex(
     input  wire        clk,
     input  wire        rst,
@@ -18,6 +20,8 @@ module stage3ex(
     input  wire [5:0]  imm_val_in,
     input  wire [5:0]  off_in,
     input  wire        sgn_en_in,
+    input  wire [11:0] src_data_in,
+    input  wire [11:0] tgt_data_in,
     output wire [11:0] pc_out,
     output wire [11:0] instr_out,
     output wire [3:0]  instr_set_out,
@@ -30,7 +34,9 @@ module stage3ex(
     output wire        imm_hilo_out,
     output wire [5:0]  imm_val_out,
     output wire [5:0]  off_out,
-    output wire        sgn_en_out
+    output wire        sgn_en_out,
+    output wire [11:0] result_out,
+    output wire [3:0]  flags_out
 );
     // The execute stage currently performs no operations.  The program
     // counter is simply forwarded to the next pipeline stage while the
@@ -51,6 +57,25 @@ module stage3ex(
     wire [5:0]  stage_off      = off_in;
     wire        stage_sgn_en   = sgn_en_in;
 
+    // Immediate value expansion
+    wire [11:0] imm_ext_tmp  = stage_sgn_en ? {{6{stage_imm_val[5]}}, stage_imm_val}
+                                            : {6'b0, stage_imm_val};
+    wire [11:0] imm_ext      = stage_imm_hilo ? (imm_ext_tmp << 6) : imm_ext_tmp;
+
+    // ALU instantiation
+    wire [11:0] alu_result;
+    wire [3:0]  alu_flags;
+    alu u_alu(
+        .opcode(instr_in[11:8]),
+        .src(src_data_in),
+        .tgt(tgt_data_in),
+        .imm(imm_ext),
+        .imm_en(stage_imm_en),
+        .sgn_en(stage_sgn_en),
+        .result(alu_result),
+        .flags(alu_flags)
+    );
+
     // Latch registers between EX and MA stages
     reg [11:0] pc_latch;
     reg [11:0] instr_latch;
@@ -65,6 +90,8 @@ module stage3ex(
     reg [5:0]  imm_val_latch;
     reg [5:0]  off_latch;
     reg        sgn_en_latch;
+    reg [11:0] result_latch;
+    reg [3:0]  flags_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
@@ -81,6 +108,8 @@ module stage3ex(
             imm_val_latch  <= 6'b0;
             off_latch      <= 6'b0;
             sgn_en_latch   <= 1'b0;
+            result_latch   <= 12'b0;
+            flags_latch    <= 4'b0;
         end else if (enable_in) begin
             pc_latch       <= stage_pc;
             instr_latch    <= instr_in;
@@ -95,6 +124,8 @@ module stage3ex(
             imm_val_latch  <= stage_imm_val;
             off_latch      <= stage_off;
             sgn_en_latch   <= stage_sgn_en;
+            result_latch   <= alu_result;
+            flags_latch    <= alu_flags;
         end
     end
 
@@ -111,4 +142,6 @@ module stage3ex(
     assign imm_val_out   = imm_val_latch;
     assign off_out       = off_latch;
     assign sgn_en_out    = sgn_en_latch;
+    assign result_out    = result_latch;
+    assign flags_out     = flags_latch;
 endmodule

--- a/src/stage4ma.v
+++ b/src/stage4ma.v
@@ -8,9 +8,13 @@ module stage4ma(
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
     input  wire [3:0]  instr_set_in,
+    input  wire [11:0] result_in,
+    input  wire [3:0]  flags_in,
     output wire [11:0] pc_out,
     output wire [11:0] instr_out,
-    output wire [3:0]  instr_set_out
+    output wire [3:0]  instr_set_out,
+    output wire [11:0] result_out,
+    output wire [3:0]  flags_out
 );
     // The Memory Address stage currently performs no modifications to the
     // program counter.  The value is simply forwarded to the next stage while
@@ -20,25 +24,35 @@ module stage4ma(
     // Stage output prior to latching.  Kept as a separate wire so that future
     // memory address logic can easily be inserted here.
     wire [11:0] stage_pc = pc_in;
+    wire [11:0] stage_result = result_in;
+    wire [3:0]  stage_flags  = flags_in;
 
     // Latch registers between MA and MO stages
     reg [11:0] pc_latch;
     reg [11:0] instr_latch;
     reg [3:0]  set_latch;
+    reg [11:0] result_latch;
+    reg [3:0]  flags_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             pc_latch    <= 12'b0;
             instr_latch <= 12'b0;
             set_latch   <= `ISET_R;
+            result_latch<= 12'b0;
+            flags_latch <= 4'b0;
         end else if (enable_in) begin
             pc_latch    <= stage_pc;
             instr_latch <= instr_in;
             set_latch   <= instr_set_in;
+            result_latch<= stage_result;
+            flags_latch <= stage_flags;
         end
     end
 
     assign pc_out        = pc_latch;
     assign instr_out     = instr_latch;
     assign instr_set_out = set_latch;
+    assign result_out    = result_latch;
+    assign flags_out     = flags_latch;
 endmodule

--- a/src/stage4mo.v
+++ b/src/stage4mo.v
@@ -8,9 +8,13 @@ module stage4mo(
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
     input  wire [3:0]  instr_set_in,
+    input  wire [11:0] result_in,
+    input  wire [3:0]  flags_in,
     output wire [11:0] pc_out,
     output wire [11:0] instr_out,
-    output wire [3:0]  instr_set_out
+    output wire [3:0]  instr_set_out,
+    output wire [11:0] result_out,
+    output wire [3:0]  flags_out
 );
     // Propagate enable directly to the next stage
     assign enable_out = enable_in;
@@ -18,25 +22,35 @@ module stage4mo(
     // The Memory Operation stage currently performs no logic and simply
     // forwards the program counter.
     wire [11:0] stage_pc = pc_in;
+    wire [11:0] stage_result = result_in;
+    wire [3:0]  stage_flags  = flags_in;
 
     // Latch registers between the MO stage and the Register Address stage
     reg [11:0] pc_latch;
     reg [11:0] instr_latch;
     reg [3:0]  set_latch;
+    reg [11:0] result_latch;
+    reg [3:0]  flags_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             pc_latch    <= 12'b0;
             instr_latch <= 12'b0;
             set_latch   <= `ISET_R;
+            result_latch<= 12'b0;
+            flags_latch <= 4'b0;
         end else if (enable_in) begin
             pc_latch    <= stage_pc;
             instr_latch <= instr_in;
             set_latch   <= instr_set_in;
+            result_latch<= stage_result;
+            flags_latch <= stage_flags;
         end
     end
 
     assign pc_out        = pc_latch;
     assign instr_out     = instr_latch;
     assign instr_set_out = set_latch;
+    assign result_out    = result_latch;
+    assign flags_out     = flags_latch;
 endmodule

--- a/src/stage5ra.v
+++ b/src/stage5ra.v
@@ -8,9 +8,13 @@ module stage5ra(
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
     input  wire [3:0]  instr_set_in,
+    input  wire [11:0] result_in,
+    input  wire [3:0]  flags_in,
     output wire [11:0] pc_out,
     output wire [11:0] instr_out,
-    output wire [3:0]  instr_set_out
+    output wire [3:0]  instr_set_out,
+    output wire [11:0] result_out,
+    output wire [3:0]  flags_out
 );
     // Propagate enable directly to the next stage
     assign enable_out = enable_in;
@@ -18,25 +22,35 @@ module stage5ra(
     // The Register Address stage currently performs no logic and simply
     // forwards the program counter.
     wire [11:0] stage_pc = pc_in;
+    wire [11:0] stage_result = result_in;
+    wire [3:0]  stage_flags  = flags_in;
 
     // Latch registers between RA and RO stages
     reg [11:0] pc_latch;
     reg [11:0] instr_latch;
     reg [3:0]  set_latch;
+    reg [11:0] result_latch;
+    reg [3:0]  flags_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             pc_latch    <= 12'b0;
             instr_latch <= 12'b0;
             set_latch   <= `ISET_R;
+            result_latch<= 12'b0;
+            flags_latch <= 4'b0;
         end else if (enable_in) begin
             pc_latch    <= stage_pc;
             instr_latch <= instr_in;
             set_latch   <= instr_set_in;
+            result_latch<= stage_result;
+            flags_latch <= stage_flags;
         end
     end
 
     assign pc_out        = pc_latch;
     assign instr_out     = instr_latch;
     assign instr_set_out = set_latch;
+    assign result_out    = result_latch;
+    assign flags_out     = flags_latch;
 endmodule

--- a/src/stage5ro.v
+++ b/src/stage5ro.v
@@ -1,4 +1,6 @@
 // stage5ro.v
+`include "src/opcodes.vh"
+`include "src/flags.vh"
 module stage5ro(
     input  wire        clk,
     input  wire        rst,
@@ -6,12 +8,42 @@ module stage5ro(
     input  wire [11:0] pc_in,
     input  wire [11:0] instr_in,
     input  wire [3:0]  instr_set_in,
+    input  wire [11:0] result_in,
+    input  wire [3:0]  flags_in,
     output wire [11:0] pc_out,
     output wire [11:0] instr_out,
-    output wire [3:0]  instr_set_out
+    output wire [3:0]  instr_set_out,
+    output wire [3:0]  reg_waddr,
+    output wire [11:0] reg_wdata,
+    output wire        reg_we,
+    output wire [3:0]  flag_wdata,
+    output wire        flag_we
 );
-    // Final Register Operation stage currently performs no logic.
-    // Propagate the program counter and instruction information.
+    // Decode opcode for write-back decisions
+    wire [3:0] opcode = instr_in[11:8];
+
+    wire reg_write = (opcode == `OPC_R_MOV  || opcode == `OPC_R_ADD ||
+                      opcode == `OPC_R_SUB || opcode == `OPC_R_NOT ||
+                      opcode == `OPC_R_AND || opcode == `OPC_R_OR  ||
+                      opcode == `OPC_R_XOR || opcode == `OPC_R_SL  ||
+                      opcode == `OPC_R_SR  || opcode == `OPC_I_MOVi ||
+                      opcode == `OPC_I_ADDi|| opcode == `OPC_I_SUBi||
+                      opcode == `OPC_I_ANDi|| opcode == `OPC_I_ORi ||
+                      opcode == `OPC_I_XORi|| opcode == `OPC_I_SLi ||
+                      opcode == `OPC_I_SRi || opcode == `OPC_I_Li  ||
+                      opcode == `OPC_RS_ADDs || opcode == `OPC_RS_SUBs ||
+                      opcode == `OPC_RS_SRs  || opcode == `OPC_IS_MOVis ||
+                      opcode == `OPC_IS_ADDis|| opcode == `OPC_IS_SUBis||
+                      opcode == `OPC_IS_SRis);
+
+    assign reg_waddr  = instr_in[7:4];
+    assign reg_wdata  = result_in;
+    assign reg_we     = enable_in && reg_write;
+
+    assign flag_wdata = flags_in;
+    assign flag_we    = enable_in;
+
+    // Propagate program counter and instruction info
     assign pc_out        = pc_in;
     assign instr_out     = instr_in;
     assign instr_set_out = instr_set_in;

--- a/src/testbench.v
+++ b/src/testbench.v
@@ -64,6 +64,15 @@ module testbench;
                  uut.mora_set,
                  uut.raro_set,
                  uut.final_set);
+        $display("tick %0d : EX_res=%h MA_res=%h MO_res=%h RA_res=%h RO_res=%h WE=%b WADDR=%h",
+                 tick,
+                 uut.ex_result,
+                 uut.ma_result,
+                 uut.mo_result,
+                 uut.ra_result,
+                 uut.ro_result,
+                 uut.reg_we,
+                 uut.reg_waddr);
         tick = tick + 1;
     end
 endmodule


### PR DESCRIPTION
## Summary
- implement an `alu` capable of common register and immediate ops
- pass operands from register file in `stage3ex` and latch ALU results/flags
- propagate ALU outputs through MA/MO/RA stages
- perform write-back and flag updates in `stage5ro`
- instantiate register and flag files in `henad`
- extend `testbench` to observe ALU and register activity

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp > sim.out`

------
https://chatgpt.com/codex/tasks/task_e_68587793dcfc832fa839fceb1907d0d9