### PR TITLE
Implement register address setup in writeback stage

### DIFF
--- a/src/henad.v
+++ b/src/henad.v
@@ -91,6 +91,7 @@ module henad(
     wire [3:0]  mo_flags;
     wire [11:0] ra_result;
     wire [3:0]  ra_flags;
+    wire [3:0]  ra_reg_waddr;
     wire [11:0] ro_result;
     wire [3:0]  ro_flags;
     wire [3:0]  reg_waddr;
@@ -308,7 +309,8 @@ module henad(
         .instr_out(raro_instr),
         .instr_set_out(raro_set),
         .result_out(ra_result),
-        .flags_out(ra_flags)
+        .flags_out(ra_flags),
+        .reg_waddr_out(ra_reg_waddr)
     );
 
     // Register operation stage
@@ -321,6 +323,7 @@ module henad(
         .instr_set_in(raro_set),
         .result_in(ra_result),
         .flags_in(ra_flags),
+        .reg_waddr_in(ra_reg_waddr),
         .pc_out(final_pc),
         .instr_out(final_instr),
         .instr_set_out(final_set),

--- a/src/stage5ra.v
+++ b/src/stage5ra.v
@@ -14,16 +14,20 @@ module stage5ra(
     output wire [11:0] instr_out,
     output wire [3:0]  instr_set_out,
     output wire [11:0] result_out,
-    output wire [3:0]  flags_out
+    output wire [3:0]  flags_out,
+    // Decoded register address for the writeback stage
+    output wire [3:0]  reg_waddr_out
 );
     // Propagate enable directly to the next stage
     assign enable_out = enable_in;
 
     // The Register Address stage currently performs no logic and simply
     // forwards the program counter.
-    wire [11:0] stage_pc = pc_in;
+    wire [11:0] stage_pc     = pc_in;
     wire [11:0] stage_result = result_in;
     wire [3:0]  stage_flags  = flags_in;
+    // Target register address extracted from the instruction
+    wire [3:0]  stage_waddr  = instr_in[7:4];
 
     // Latch registers between RA and RO stages
     reg [11:0] pc_latch;
@@ -31,6 +35,7 @@ module stage5ra(
     reg [3:0]  set_latch;
     reg [11:0] result_latch;
     reg [3:0]  flags_latch;
+    reg [3:0]  waddr_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
@@ -39,12 +44,14 @@ module stage5ra(
             set_latch   <= `ISET_R;
             result_latch<= 12'b0;
             flags_latch <= 4'b0;
+            waddr_latch <= 4'b0;
         end else if (enable_in) begin
-            pc_latch    <= stage_pc;
-            instr_latch <= instr_in;
-            set_latch   <= instr_set_in;
-            result_latch<= stage_result;
-            flags_latch <= stage_flags;
+            pc_latch     <= stage_pc;
+            instr_latch  <= instr_in;
+            set_latch    <= instr_set_in;
+            result_latch <= stage_result;
+            flags_latch  <= stage_flags;
+            waddr_latch  <= stage_waddr;
         end
     end
 
@@ -53,4 +60,5 @@ module stage5ra(
     assign instr_set_out = set_latch;
     assign result_out    = result_latch;
     assign flags_out     = flags_latch;
+    assign reg_waddr_out = waddr_latch;
 endmodule

--- a/src/stage5ro.v
+++ b/src/stage5ro.v
@@ -10,6 +10,8 @@ module stage5ro(
     input  wire [3:0]  instr_set_in,
     input  wire [11:0] result_in,
     input  wire [3:0]  flags_in,
+    // Register address prepared by the RA stage
+    input  wire [3:0]  reg_waddr_in,
     output wire [11:0] pc_out,
     output wire [11:0] instr_out,
     output wire [3:0]  instr_set_out,
@@ -36,7 +38,8 @@ module stage5ro(
                       opcode == `OPC_IS_ADDis|| opcode == `OPC_IS_SUBis||
                       opcode == `OPC_IS_SRis || opcode == `OPC_IS_Lis);
 
-    assign reg_waddr  = instr_in[7:4];
+    // Pass through the address computed in the RA stage
+    assign reg_waddr  = reg_waddr_in;
     assign reg_wdata  = result_in;
     assign reg_we     = enable_in && reg_write;
 


### PR DESCRIPTION
## Summary
- extend stage5ra with register address latch for writeback
- pass computed register address to stage5ro
- update top‐level pipeline wiring for the new signal

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_685920513024832fb29b55f3e26e9d2d