### PR TITLE
Use instruction set with opcode across stages

### DIFF
--- a/src/stage4ma.v
+++ b/src/stage4ma.v
@@ -30,10 +30,10 @@ module stage4ma(
     // address. Otherwise the original PC is forwarded.  Keeping this in a
     // separate wire allows for future memory address calculations.
     wire [3:0] opcode = instr_in[11:8];
-    wire branch_instr = (opcode == `OPC_R_BCC)  ||
-                        (opcode == `OPC_I_BCCi) ||
-                        (opcode == `OPC_IS_BCCis) ||
-                        (opcode == `OPC_S_SRBCC);
+    wire branch_instr = ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_BCC})  ||
+                        ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_BCCi}) ||
+                        ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_BCCis}) ||
+                        ({instr_set_in, opcode} == {`ISET_S,  `OPC_S_SRBCC});
     wire [11:0] stage_pc = branch_instr ? result_in : pc_in;
     wire [11:0] stage_result = result_in;
     wire [3:0]  stage_flags  = flags_in;
@@ -42,8 +42,10 @@ module stage4ma(
     // Determine if this is a memory access instruction and set the
     // data memory address accordingly.  The execute stage provides the
     // address to access in result_in for load/store instructions.
-    wire mem_instr = (opcode == `OPC_R_LD)  || (opcode == `OPC_I_LDi) ||
-                     (opcode == `OPC_R_ST) || (opcode == `OPC_I_STi);
+    wire mem_instr = ({instr_set_in, opcode} == {`ISET_R, `OPC_R_LD})  ||
+                     ({instr_set_in, opcode} == {`ISET_I, `OPC_I_LDi}) ||
+                     ({instr_set_in, opcode} == {`ISET_R, `OPC_R_ST}) ||
+                     ({instr_set_in, opcode} == {`ISET_I, `OPC_I_STi});
     assign mem_addr = mem_instr ? result_in : 12'b0;
 
     // Latch registers between MA and MO stages

--- a/src/stage4mo.v
+++ b/src/stage4mo.v
@@ -28,10 +28,10 @@ module stage4mo(
 
     // Decode opcode for load/store behaviour
     wire [3:0] opcode = instr_in[11:8];
-    wire       load_instr  = (opcode == `OPC_R_LD)  ||
-                             (opcode == `OPC_I_LDi);
-    wire       store_instr = (opcode == `OPC_R_ST)  ||
-                             (opcode == `OPC_I_STi);
+    wire       load_instr  = ({instr_set_in, opcode} == {`ISET_R, `OPC_R_LD})  ||
+                             ({instr_set_in, opcode} == {`ISET_I, `OPC_I_LDi});
+    wire       store_instr = ({instr_set_in, opcode} == {`ISET_R, `OPC_R_ST})  ||
+                             ({instr_set_in, opcode} == {`ISET_I, `OPC_I_STi});
 
     // For load instructions use the memory data as the result.  All
     // other instructions simply forward the execute stage result.

--- a/src/stage5ro.v
+++ b/src/stage5ro.v
@@ -24,20 +24,34 @@ module stage5ro(
     // Decode opcode for write-back decisions
     wire [3:0] opcode = instr_in[11:8];
 
-    wire reg_write = (opcode == `OPC_R_MOV  || opcode == `OPC_R_ADD ||
-                      opcode == `OPC_R_SUB || opcode == `OPC_R_NOT ||
-                      opcode == `OPC_R_AND || opcode == `OPC_R_OR  ||
-                      opcode == `OPC_R_XOR || opcode == `OPC_R_SL  ||
-                      opcode == `OPC_R_SR  || opcode == `OPC_R_LD  ||
-                      opcode == `OPC_I_MOVi || opcode == `OPC_I_ADDi||
-                      opcode == `OPC_I_SUBi|| opcode == `OPC_I_ANDi||
-                      opcode == `OPC_I_ORi || opcode == `OPC_I_XORi||
-                      opcode == `OPC_I_SLi || opcode == `OPC_I_SRi ||
-                      opcode == `OPC_I_LDi || opcode == `OPC_I_Li  ||
-                      opcode == `OPC_RS_ADDs || opcode == `OPC_RS_SUBs ||
-                      opcode == `OPC_RS_SRs  || opcode == `OPC_IS_MOVis ||
-                      opcode == `OPC_IS_ADDis|| opcode == `OPC_IS_SUBis||
-                      opcode == `OPC_IS_SRis || opcode == `OPC_IS_Lis);
+    wire reg_write = ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_MOV})  ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_MOVi}) ||
+                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_MOVis}) ||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_ADD})  ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_ADDi}) ||
+                     ({instr_set_in, opcode} == {`ISET_RS, `OPC_RS_ADDs}) ||
+                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_ADDis})||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_SUB})  ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_SUBi}) ||
+                     ({instr_set_in, opcode} == {`ISET_RS, `OPC_RS_SUBs}) ||
+                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_SUBis})||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_NOT})  ||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_AND})  ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_ANDi}) ||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_OR})   ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_ORi})  ||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_XOR})  ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_XORi}) ||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_SL})   ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_SLi})  ||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_SR})   ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_SRi})  ||
+                     ({instr_set_in, opcode} == {`ISET_RS, `OPC_RS_SRs}) ||
+                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_SRis})||
+                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_LD})   ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_LDi})  ||
+                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_Li})   ||
+                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_Lis});
 
     // Pass through the address computed in the RA stage
     assign reg_waddr  = reg_waddr_in;


### PR DESCRIPTION
## Summary
- handle branch, memory and writeback logic with combined instruction set/opcode
- update MA, MO and RO stages accordingly

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`


------
https://chatgpt.com/codex/tasks/task_e_685927e44894832f932bfd9ed03932ea