### PR TITLE
Add simple RAW hazard stall

### DIFF
--- a/src/hazardunit.v
+++ b/src/hazardunit.v
@@ -1,4 +1,80 @@
 // hazardunit.v
-module hazardunit();
-    // Hazard detection logic for pipeline
+`include "src/opcodes.vh"
+`include "src/iset.vh"
+
+// Hazard detection unit for simple read-after-write stalls. The unit looks at
+// the register addresses used by the decode stage and compares them with the
+// destination registers of instructions in the pipeline that have not yet
+// written their results back. If a match is found, a stall signal is asserted so
+// that the IF and ID stages can be paused.
+module hazardunit(
+    // Register numbers currently being read in the decode stage
+    input  wire [3:0] id_src_gp,
+    input  wire [3:0] id_tgt_gp,
+
+    // Instructions further down the pipeline.  Only the sets and opcodes are
+    // required to determine if they will write back to the register file.
+    input  wire [11:0] idex_instr,
+    input  wire [3:0]  idex_set,
+    input  wire [11:0] exma_instr,
+    input  wire [3:0]  exma_set,
+    input  wire [11:0] mamo_instr,
+    input  wire [3:0]  mamo_set,
+
+    // Asserted when a hazard is detected
+    output wire        stall
+);
+    // -------------------------------------------------------------
+    // Helper function used to decide if an instruction writes to the
+    // general purpose register file.  The logic mirrors the write-back
+    // decision used in stage5ro so that this unit remains consistent
+    // with the final pipeline stage.
+    function automatic reg_write_fn;
+        input [3:0] set;
+        input [3:0] opc;
+        begin
+            reg_write_fn = ({set, opc} == {`ISET_R,  `OPC_R_MOV})  ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_MOVi}) ||
+                          ({set, opc} == {`ISET_IS, `OPC_IS_MOVis}) ||
+                          ({set, opc} == {`ISET_R,  `OPC_R_ADD})  ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_ADDi}) ||
+                          ({set, opc} == {`ISET_RS, `OPC_RS_ADDs}) ||
+                          ({set, opc} == {`ISET_IS, `OPC_IS_ADDis})||
+                          ({set, opc} == {`ISET_R,  `OPC_R_SUB})  ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_SUBi}) ||
+                          ({set, opc} == {`ISET_RS, `OPC_RS_SUBs}) ||
+                          ({set, opc} == {`ISET_IS, `OPC_IS_SUBis})||
+                          ({set, opc} == {`ISET_R,  `OPC_R_NOT})  ||
+                          ({set, opc} == {`ISET_R,  `OPC_R_AND})  ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_ANDi}) ||
+                          ({set, opc} == {`ISET_R,  `OPC_R_OR})   ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_ORi})  ||
+                          ({set, opc} == {`ISET_R,  `OPC_R_XOR})  ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_XORi}) ||
+                          ({set, opc} == {`ISET_R,  `OPC_R_SL})   ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_SLi})  ||
+                          ({set, opc} == {`ISET_R,  `OPC_R_SR})   ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_SRi})  ||
+                          ({set, opc} == {`ISET_RS, `OPC_RS_SRs}) ||
+                          ({set, opc} == {`ISET_IS, `OPC_IS_SRis})||
+                          ({set, opc} == {`ISET_R,  `OPC_R_LD})   ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_LDi})  ||
+                          ({set, opc} == {`ISET_I,  `OPC_I_Li})   ||
+                          ({set, opc} == {`ISET_IS, `OPC_IS_Lis});
+        end
+    endfunction
+
+    // Destination register numbers in the stages ahead of decode
+    wire [3:0] ex_waddr = idex_instr[7:4];
+    wire [3:0] ma_waddr = exma_instr[7:4];
+    wire [3:0] mo_waddr = mamo_instr[7:4];
+
+    wire hazard_ex = reg_write_fn(idex_set,  idex_instr[11:8]) &&
+                     ((ex_waddr == id_src_gp) || (ex_waddr == id_tgt_gp));
+    wire hazard_ma = reg_write_fn(exma_set,  exma_instr[11:8]) &&
+                     ((ma_waddr == id_src_gp) || (ma_waddr == id_tgt_gp));
+    wire hazard_mo = reg_write_fn(mamo_set, mamo_instr[11:8]) &&
+                     ((mo_waddr == id_src_gp) || (mo_waddr == id_tgt_gp));
+
+    assign stall = hazard_ex || hazard_ma || hazard_mo;
 endmodule

--- a/src/henad.v
+++ b/src/henad.v
@@ -70,6 +70,12 @@ module henad(
 
     reg branch_stall;
 
+    // Stall signal for read-after-write hazards
+    wire hazard_stall;
+
+    // Combined stall control used by the decode stage and PC logic
+    wire stall_signal = branch_stall || hazard_stall;
+
     // Hold the stall for a single cycle after a branch reaches the
     // execute stage.
     always @(posedge clk or posedge rst) begin
@@ -135,9 +141,9 @@ module henad(
             stage5ra_en <= 1'b0;
             stage5ro_en <= 1'b0;
         end else begin
-            stage1ia_en <= branch_stall ? 1'b0 : 1'b1;
-            stage1if_en <= branch_stall ? 1'b0 : stage1if_en_w;
-            stage2id_en <= branch_stall ? 1'b1 : stage2id_en_w;
+            stage1ia_en <= stall_signal ? 1'b0 : 1'b1;
+            stage1if_en <= stall_signal ? 1'b0 : stage1if_en_w;
+            stage2id_en <= stall_signal ? 1'b1 : stage2id_en_w;
             stage3ex_en <= stage3ex_en_w;
             stage4ma_en <= stage4ma_en_w;
             stage4mo_en <= stage4mo_en_w;
@@ -231,7 +237,7 @@ module henad(
         .imm_val_out(id_imm_val),
         .off_out(id_off),
         .sgn_en_out(id_sgn_en),
-        .stall_in(branch_stall)
+        .stall_in(stall_signal)
     );
 
     // EX stage
@@ -354,5 +360,18 @@ module henad(
         .reg_we(reg_we),
         .flag_wdata(ro_flags),
         .flag_we(flag_we)
+    );
+
+    // Hazard detection unit
+    hazardunit u_hazardunit(
+        .id_src_gp(id_src_gp),
+        .id_tgt_gp(id_tgt_gp),
+        .idex_instr(idex_instr),
+        .idex_set(idex_set),
+        .exma_instr(exma_instr),
+        .exma_set(exma_set),
+        .mamo_instr(mamo_instr),
+        .mamo_set(mamo_set),
+        .stall(hazard_stall)
     );
 endmodule


### PR DESCRIPTION
## Summary
- implement a `hazardunit` that detects read-after-write register hazards
- wire hazard stall into the core so IF/ID pause when a hazard is seen

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_68592d4ee370832fa2291d17ceeac87f