### PR TITLE
Share register-write check

### DIFF
--- a/src/hazardunit.v
+++ b/src/hazardunit.v
@@ -24,45 +24,10 @@ module hazardunit(
     // Asserted when a hazard is detected
     output wire        stall
 );
-    // -------------------------------------------------------------
-    // Helper function used to decide if an instruction writes to the
-    // general purpose register file.  The logic mirrors the write-back
-    // decision used in stage5ro so that this unit remains consistent
-    // with the final pipeline stage.
-    function automatic reg_write_fn;
-        input [3:0] set;
-        input [3:0] opc;
-        begin
-            reg_write_fn = ({set, opc} == {`ISET_R,  `OPC_R_MOV})  ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_MOVi}) ||
-                          ({set, opc} == {`ISET_IS, `OPC_IS_MOVis}) ||
-                          ({set, opc} == {`ISET_R,  `OPC_R_ADD})  ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_ADDi}) ||
-                          ({set, opc} == {`ISET_RS, `OPC_RS_ADDs}) ||
-                          ({set, opc} == {`ISET_IS, `OPC_IS_ADDis})||
-                          ({set, opc} == {`ISET_R,  `OPC_R_SUB})  ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_SUBi}) ||
-                          ({set, opc} == {`ISET_RS, `OPC_RS_SUBs}) ||
-                          ({set, opc} == {`ISET_IS, `OPC_IS_SUBis})||
-                          ({set, opc} == {`ISET_R,  `OPC_R_NOT})  ||
-                          ({set, opc} == {`ISET_R,  `OPC_R_AND})  ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_ANDi}) ||
-                          ({set, opc} == {`ISET_R,  `OPC_R_OR})   ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_ORi})  ||
-                          ({set, opc} == {`ISET_R,  `OPC_R_XOR})  ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_XORi}) ||
-                          ({set, opc} == {`ISET_R,  `OPC_R_SL})   ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_SLi})  ||
-                          ({set, opc} == {`ISET_R,  `OPC_R_SR})   ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_SRi})  ||
-                          ({set, opc} == {`ISET_RS, `OPC_RS_SRs}) ||
-                          ({set, opc} == {`ISET_IS, `OPC_IS_SRis})||
-                          ({set, opc} == {`ISET_R,  `OPC_R_LD})   ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_LDi})  ||
-                          ({set, opc} == {`ISET_I,  `OPC_I_Li})   ||
-                          ({set, opc} == {`ISET_IS, `OPC_IS_Lis});
-        end
-    endfunction
+    // Bring in the shared reg_write_fn helper
+    `define DEFINE_REG_WRITE_FN
+    `include "src/iset.vh"
+    `undef DEFINE_REG_WRITE_FN
 
     // Destination register numbers in the stages ahead of decode
     wire [3:0] ex_waddr = idex_instr[7:4];

--- a/src/iset.vh
+++ b/src/iset.vh
@@ -11,3 +11,48 @@
 `define ISET_S  4'h4 // Special set
 
 `endif // ISET_VH
+
+// -------------------------------------------------------------
+// Common helper logic
+
+// reg_write_fn
+// Return 1 when the combination of instruction set and opcode
+// writes to the general purpose register file.  Modules that
+// require this function should define `DEFINE_REG_WRITE_FN` before
+// including this header inside their scope.
+`ifdef DEFINE_REG_WRITE_FN
+function automatic reg_write_fn;
+    input [3:0] set;
+    input [3:0] opc;
+    begin
+        reg_write_fn = ({set, opc} == {`ISET_R,  `OPC_R_MOV})  ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_MOVi}) ||
+                       ({set, opc} == {`ISET_IS, `OPC_IS_MOVis}) ||
+                       ({set, opc} == {`ISET_R,  `OPC_R_ADD})  ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_ADDi}) ||
+                       ({set, opc} == {`ISET_RS, `OPC_RS_ADDs}) ||
+                       ({set, opc} == {`ISET_IS, `OPC_IS_ADDis})||
+                       ({set, opc} == {`ISET_R,  `OPC_R_SUB})  ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_SUBi}) ||
+                       ({set, opc} == {`ISET_RS, `OPC_RS_SUBs}) ||
+                       ({set, opc} == {`ISET_IS, `OPC_IS_SUBis})||
+                       ({set, opc} == {`ISET_R,  `OPC_R_NOT})  ||
+                       ({set, opc} == {`ISET_R,  `OPC_R_AND})  ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_ANDi}) ||
+                       ({set, opc} == {`ISET_R,  `OPC_R_OR})   ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_ORi})  ||
+                       ({set, opc} == {`ISET_R,  `OPC_R_XOR})  ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_XORi}) ||
+                       ({set, opc} == {`ISET_R,  `OPC_R_SL})   ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_SLi})  ||
+                       ({set, opc} == {`ISET_R,  `OPC_R_SR})   ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_SRi})  ||
+                       ({set, opc} == {`ISET_RS, `OPC_RS_SRs}) ||
+                       ({set, opc} == {`ISET_IS, `OPC_IS_SRis})||
+                       ({set, opc} == {`ISET_R,  `OPC_R_LD})   ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_LDi})  ||
+                       ({set, opc} == {`ISET_I,  `OPC_I_Li})   ||
+                       ({set, opc} == {`ISET_IS, `OPC_IS_Lis});
+    end
+endfunction
+`endif // DEFINE_REG_WRITE_FN

--- a/src/stage5ro.v
+++ b/src/stage5ro.v
@@ -1,6 +1,7 @@
 // stage5ro.v
 `include "src/opcodes.vh"
 `include "src/flags.vh"
+`include "src/iset.vh"
 module stage5ro(
     input  wire        clk,
     input  wire        rst,
@@ -21,37 +22,14 @@ module stage5ro(
     output wire [3:0]  flag_wdata,
     output wire        flag_we
 );
+    // Bring in the shared reg_write_fn helper
+    `define DEFINE_REG_WRITE_FN
+    `include "src/iset.vh"
+    `undef DEFINE_REG_WRITE_FN
     // Decode opcode for write-back decisions
     wire [3:0] opcode = instr_in[11:8];
 
-    wire reg_write = ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_MOV})  ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_MOVi}) ||
-                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_MOVis}) ||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_ADD})  ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_ADDi}) ||
-                     ({instr_set_in, opcode} == {`ISET_RS, `OPC_RS_ADDs}) ||
-                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_ADDis})||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_SUB})  ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_SUBi}) ||
-                     ({instr_set_in, opcode} == {`ISET_RS, `OPC_RS_SUBs}) ||
-                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_SUBis})||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_NOT})  ||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_AND})  ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_ANDi}) ||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_OR})   ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_ORi})  ||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_XOR})  ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_XORi}) ||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_SL})   ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_SLi})  ||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_SR})   ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_SRi})  ||
-                     ({instr_set_in, opcode} == {`ISET_RS, `OPC_RS_SRs}) ||
-                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_SRis})||
-                     ({instr_set_in, opcode} == {`ISET_R,  `OPC_R_LD})   ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_LDi})  ||
-                     ({instr_set_in, opcode} == {`ISET_I,  `OPC_I_Li})   ||
-                     ({instr_set_in, opcode} == {`ISET_IS, `OPC_IS_Lis});
+    wire reg_write = reg_write_fn(instr_set_in, opcode);
 
     // Pass through the address computed in the RA stage
     assign reg_waddr  = reg_waddr_in;


### PR DESCRIPTION
## Summary
- add `reg_write_fn` helper to `iset.vh`
- reuse the helper in `hazardunit.v` and `stage5ro.v`

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_68593fb134b8832fbbefc28a32592b02