### PR TITLE
Fix SW instruction switching instruction set

### DIFF
--- a/src/henad.v
+++ b/src/henad.v
@@ -51,6 +51,7 @@ module henad(
     wire [11:0] final_instr;
 
 
+    reg  [3:0] ifid_set_reg;
     wire [3:0] ifid_set;
     // Instruction set value at each pipeline stage
     wire [3:0] idex_set;
@@ -222,8 +223,22 @@ module henad(
     );
 
 
-    // Initial instruction set for the pipeline
-    assign ifid_set = `ISET_R;
+    // Instruction set tracking register.  The decode stage outputs the set
+    // for the current instruction and this register feeds the next
+    // instruction into the pipeline so that SW instructions take effect.
+    assign ifid_set = ifid_set_reg;
+
+    // Determine the instruction set for the next instruction.  A switch (SW)
+    // instruction selects a new set; otherwise the current set is preserved.
+    wire [3:0] next_ifid_set =
+        (ifid_instr[11:8] == `OPC_SW) ? {1'b0, ifid_instr[2:0]} : ifid_set_reg;
+
+    always @(posedge clk or posedge rst) begin
+        if (rst)
+            ifid_set_reg <= `ISET_R;
+        else if (stage2id_en)
+            ifid_set_reg <= next_ifid_set;
+    end
 
     // ID stage
     stage2id u_stage2id(


### PR DESCRIPTION
## Summary
- track the active instruction set in `henad.v`
- update it when a `SW` instruction is decoded

This lets a `SW` instruction correctly change the opcode set so that
subsequent instructions are decoded according to the new set.

## Testing
- `iverilog -g2012 -o test.vvp src/*.v && vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_685ab8d55b8c832f9ade2dad8d72b40b