### PR TITLE
Add static array support to Skald

### DIFF
--- a/processors/amber/skald/README.md
+++ b/processors/amber/skald/README.md
@@ -23,6 +23,13 @@ Status: skeleton only
   - Strict typing: no implicit casts between `u24` and `s24`.
     Use explicit casts where needed. No implicit casts to/from `addr<T>`.
 
+Arrays
+- Declare with `let a: T[N];` where `T` is `u24`, `s24`, any `addr<...>`, or a
+  user-defined `struct`.
+- Arrays are stack-allocated with the variable bound to a base pointer in an
+  address register. Index elements via `a[i]`; struct arrays allow field access
+  such as `a[i].field`.
+
 Structs
 - Declare with `struct Name { field: type; ... }` at top-level.
 - Local `let v: Name;` allocates a stack-backed instance and binds `v` to an

--- a/processors/amber/skald/examples/array.skald
+++ b/processors/amber/skald/examples/array.skald
@@ -1,0 +1,14 @@
+struct Pair { a: u24; b: s24; }
+
+fn main() {
+    let data: u24[4];
+    let i: u24;
+    i = 1;
+    data[0] = 5;
+    data[i] = 7;
+    let x: u24;
+    x = data[i];
+    let pairs: Pair[2];
+    pairs[1].a = x;
+    return;
+}


### PR DESCRIPTION
## Summary
- allow array types of primitive, address and struct elements
- implement array indexing/assignment in code generator
- document and demonstrate arrays in Skald examples

## Testing
- `python -m processors.amber.skald processors/amber/skald/examples/array.skald -o /tmp/array.asm`
- `python -m processors.amber.skald processors/amber/skald/examples/struct.skald -o /tmp/struct.asm`


------
https://chatgpt.com/codex/tasks/task_e_68bd4dfbb8e0832fa971bbd1108ea47f